### PR TITLE
Fixing Tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,49 +2,64 @@
 
 
 [[projects]]
+  digest = "1:b801fcfde3e5b0b997919941238438a7eb5ca43e431467e19540b59626908e18"
   name = "github.com/DataDog/datadog-go"
   packages = ["statsd"]
+  pruneopts = ""
   revision = "0ddda6bee21174ef6c4873647cb0d6ec9cba996f"
   version = "1.1.0"
 
 [[projects]]
+  digest = "1:73ec5e4a5b52be94cf0efee29713e78e229696eb733063f85bebdd8fce337b8b"
   name = "github.com/certifi/gocertifi"
   packages = ["."]
+  pruneopts = ""
   revision = "a9c833d2837d3b16888d55d5aafa9ffe9afb22b0"
   version = "2017.04.17"
 
 [[projects]]
+  digest = "1:82b6c6a7f7f55495200481260dc7d81b3568d2f7e27310d3e6e4df2b7b8b7659"
   name = "github.com/confluentinc/confluent-kafka-go"
   packages = ["kafka"]
+  pruneopts = ""
   revision = "5e4d04e05fc319ce5996a867aafef29059f26862"
   version = "v0.11.4"
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:bb522d6790c531be0b6631f1110e47623d3307672d66749054fa31ddd8878a7d"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = ""
   revision = "d2709f9f1f31ebcda9651b03077758c1f3a0018c"
   version = "v3.0.0"
 
 [[projects]]
+  digest = "1:9f1e571696860f2b4f8a241b43ce91c6085e7aaed849ccca53f590a4dc7b95bd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = ""
   revision = "629574ca2a5df945712d3079857300b5e4da0236"
   version = "v1.4.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:82da6a2b72827cb7031d3b9e44e24aebcf17e878e4c8af6ba16503021e2de6f9"
   name = "github.com/getsentry/raven-go"
   packages = ["."]
+  pruneopts = ""
   revision = "d175f85701dfbf44cb0510114c9943e665e60907"
 
 [[projects]]
   branch = "master"
+  digest = "1:54154e6dbc8ce9438f24131cabfeaada1582b35fcdb2ff8457b77a4b1b9a13af"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -55,47 +70,61 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = ""
   revision = "392dba7d905ed5d04a5794ba89f558b27e2ba1ca"
 
 [[projects]]
   branch = "master"
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
 
 [[projects]]
   branch = "master"
+  digest = "1:a0c0f06f12f4b83b89eec79114265c54e9e300b8ddda0f0f3fb49a685283fa6c"
   name = "github.com/jinzhu/inflection"
   packages = ["."]
+  pruneopts = ""
   revision = "1c35d901db3da928c72a72d8458480cc9ade058f"
 
 [[projects]]
   branch = "master"
+  digest = "1:92eb5f6417553236f50fec6d0a61e1a75285e9b8855c69d239111d747b48c86a"
   name = "github.com/jpillora/backoff"
   packages = ["."]
+  pruneopts = ""
   revision = "06c7a16c845dc8e0bf575fafeeca0f5462f5eb4d"
 
 [[projects]]
+  digest = "1:1ce378ab2352c756c6d7a0172c22ecbd387659d32712a4ce3bc474273309a5dc"
   name = "github.com/magiconair/properties"
   packages = ["."]
+  pruneopts = ""
   revision = "be5ece7dd465ab0765a9682137865547526d1dfb"
   version = "v1.7.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:fdea706e507511c18a18391880bbae9379413c5dcffacd2211cbaaec2a4a1541"
   name = "github.com/mattn/go-xmpp"
   packages = ["."]
+  pruneopts = ""
   revision = "906d9d747d2b4c59e60104678b62e464dd1623cf"
 
 [[projects]]
   branch = "master"
+  digest = "1:c9ede10a9ded782d25d1f0be87c680e11409c23554828f19a19d691a95e76130"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "d0303fe809921458f417bcf828397a65db30a7e4"
 
 [[projects]]
+  digest = "1:32b27072cd55bd2fb7244de0425943d125da6a552ae2b6517cdd965a662baf18"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -115,12 +144,14 @@
     "reporters/stenographer",
     "reporters/stenographer/support/go-colorable",
     "reporters/stenographer/support/go-isatty",
-    "types"
+    "types",
   ]
+  pruneopts = ""
   revision = "9eda700730cba42af70d53180f9dcce9266bc2bc"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:a4e59d0b2821c983b58c317f141cd77df20570979632da8a7a352e5d12698de7"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -134,130 +165,184 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types"
+    "types",
   ]
+  pruneopts = ""
   revision = "c893efa28eb45626cdaa76c9f653b62488858837"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:63e142fc50307bcb3c57494913cfc9c12f6061160bdf97a678f78c71615f939b"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:049b5bee78dfdc9628ee0e557219c41f683e5b06c5a5f20eaba0105ccc586689"
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
+  pruneopts = ""
   revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:6d5a9728ae27e477a07bb69f02ea0bade74eb8b0c7346d046337904bbf7af065"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
+  pruneopts = ""
   revision = "5ccdfb18c776b740aecaf085c4d9a2779199c279"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:6b55df4b0517a459af9d3879c99330af4367adcf45f3d0d37ded80a6272ae057"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = ""
   revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:67fcd8b88910b57e8824a00a862b569526381e25c22352b715e04315531fe6da"
   name = "github.com/sideshow/apns2"
   packages = [
     ".",
-    "token"
+    "token",
   ]
+  pruneopts = ""
   revision = "a3ce9c6f95f63dab4ead29da86534dd7af95271a"
   version = "v0.13"
 
 [[projects]]
+  digest = "1:77e3721e5e9e71223aed2a539f41a8098d7070f554faf16b63c933a429df1db3"
   name = "github.com/sirupsen/logrus"
   packages = [
     ".",
-    "hooks/test"
+    "hooks/test",
   ]
+  pruneopts = ""
   revision = "a3f95b5c423586578a4e099b11a46c2479628cac"
   version = "1.0.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:a35a4db30a6094deac33fdb99de9ed99fefc39a7bf06b57d9f04bcaa425bb183"
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem"
+    "mem",
   ]
+  pruneopts = ""
   revision = "9be650865eab0c12963d8753212f4f9c66cdcf12"
 
 [[projects]]
+  digest = "1:6ff9b74bfea2625f805edec59395dc37e4a06458dd3c14e3372337e3d35a2ed6"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = ""
   revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:7a2c8500a25264282635297eaf3de3281dddde62892d711f9d555607bdfac3b7"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = ""
   revision = "90fc11bbc0a789c29272c21b5ff9e93db183f8dc"
 
 [[projects]]
   branch = "master"
+  digest = "1:0f963ca61135dee190399f80203bd6dc0b4eef742ae60ddde08da68fdf2ac9f1"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
+  pruneopts = ""
   revision = "0efa5202c04663c757d84f90f5219c1250baf94f"
 
 [[projects]]
+  digest = "1:261bc565833ef4f02121450d74eb88d5ae4bd74bfe5d0e862cddb8550ec35000"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:59354ad53dfe6ed1b941844cb029cd37c0377598eec3a0d49c03aee2375ef9c4"
   name = "github.com/spf13/viper"
   packages = ["."]
+  pruneopts = ""
   revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
 
 [[projects]]
   branch = "master"
+  digest = "1:ed7ac53c7d59041f27964d3f04e021b45ecb5f23c842c84d778a7f1fb67e2ce9"
   name = "github.com/stretchr/objx"
   packages = ["."]
+  pruneopts = ""
   revision = "1a9d0bb9f541897e62256577b352fdbc1fb4fd94"
 
 [[projects]]
+  digest = "1:3926a4ec9a4ff1a072458451aa2d9b98acd059a45b38f7335d31e06c3d6a0159"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "mock"
+    "mock",
   ]
+  pruneopts = ""
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
 [[projects]]
+  digest = "1:cb1a22ff7d494bf32d904e8a52649f9615200ac2cbdd42d836c5a80a42482262"
   name = "github.com/topfreegames/go-gcm"
   packages = ["."]
+  pruneopts = ""
   revision = "31e6666875e2bf5aed58ae88c7c79f21a8188913"
   version = "v1.3"
 
 [[projects]]
+  digest = "1:1aa50e504ff54351992a2324a4aba36f8eaa9ff34308ffa6a610a8dc188332b5"
+  name = "github.com/topfreegames/pusher"
+  packages = [
+    "cmd",
+    "errors",
+    "extensions",
+    "interfaces",
+    "mocks",
+    "pusher",
+    "structs",
+    "testing",
+    "util",
+  ]
+  pruneopts = ""
+  revision = "7239579ceed0c5d4ae13af66a5e1ece9e8ccf5bd"
+  version = "3.4.2"
+
+[[projects]]
   branch = "master"
+  digest = "1:1710f8497e287491a719f21eb51b1068b224c63d31084b3d7121c6d65bc3bebf"
   name = "golang.org/x/crypto"
   packages = [
     "pkcs12",
-    "pkcs12/internal/rc2"
+    "pkcs12/internal/rc2",
   ]
+  pruneopts = ""
   revision = "6914964337150723782436d56b3f21610a74ce7b"
 
 [[projects]]
   branch = "master"
+  digest = "1:3246e12ee1c5003acebbc8ceea757df86cfc23f7a321d70d47f96b9b21462115"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -268,18 +353,22 @@
     "http2",
     "http2/hpack",
     "idna",
-    "lex/httplex"
+    "lex/httplex",
   ]
+  pruneopts = ""
   revision = "ab5485076ff3407ad2d02db054635913f017b0ed"
 
 [[projects]]
   branch = "master"
+  digest = "1:6957783a12df8ccbcff3372b12a429f0fbc55d7b6fce33910d5a8745ebf27804"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = ""
   revision = "c4489faa6e5ab84c0ef40d6ee878f7a030281f0f"
 
 [[projects]]
   branch = "master"
+  digest = "1:7e04efe14d3e705ae576fcf9c557508a2970a9b0373936482b01137964491f89"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -304,11 +393,13 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = ""
   revision = "836efe42bb4aa16aaa17b9c155d8813d336ed720"
 
 [[projects]]
+  digest = "1:6b796af3eb53018392c3803820e424b1c04e62913da54b23e8873a51c2e496b2"
   name = "gopkg.in/pg.v5"
   packages = [
     ".",
@@ -316,20 +407,50 @@
     "internal/parser",
     "internal/pool",
     "orm",
-    "types"
+    "types",
   ]
+  pruneopts = ""
   revision = "2246060a2a43f8282ad53295d56d780dbc930b7f"
   version = "v5.3.3"
 
 [[projects]]
   branch = "v2"
+  digest = "1:f776026dedad7a9fef3c65180084620ca3684a87a177f5da8837755a1f8fa4fd"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "25c4ec802a7d637f88d584ab26798e94ad14c13b"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c0fcac949df8a913c9a6a13b6f9b5d87ec5f480f86b1d5c8311150499694df9e"
+  input-imports = [
+    "github.com/DataDog/datadog-go/statsd",
+    "github.com/confluentinc/confluent-kafka-go/kafka",
+    "github.com/getsentry/raven-go",
+    "github.com/onsi/ginkgo",
+    "github.com/onsi/gomega",
+    "github.com/onsi/gomega/types",
+    "github.com/satori/go.uuid",
+    "github.com/sideshow/apns2",
+    "github.com/sideshow/apns2/token",
+    "github.com/sirupsen/logrus",
+    "github.com/sirupsen/logrus/hooks/test",
+    "github.com/spf13/cobra",
+    "github.com/spf13/viper",
+    "github.com/topfreegames/go-gcm",
+    "github.com/topfreegames/pusher/cmd",
+    "github.com/topfreegames/pusher/errors",
+    "github.com/topfreegames/pusher/extensions",
+    "github.com/topfreegames/pusher/interfaces",
+    "github.com/topfreegames/pusher/mocks",
+    "github.com/topfreegames/pusher/pusher",
+    "github.com/topfreegames/pusher/structs",
+    "github.com/topfreegames/pusher/testing",
+    "github.com/topfreegames/pusher/util",
+    "golang.org/x/crypto/pkcs12",
+    "gopkg.in/pg.v5",
+    "gopkg.in/pg.v5/types",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/certificate/certificate_test.go
+++ b/certificate/certificate_test.go
@@ -28,16 +28,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"crypto/tls"
-	"errors"
 	"io/ioutil"
 )
-
-func verifyHostname(cert tls.Certificate) error {
-	if cert.Leaf == nil {
-		return errors.New("expected leaf cert")
-	}
-	return cert.Leaf.VerifyHostname("APNS/2 Development IOS Push Services: com.sideshow.Apns2")
-}
 
 var _ = Describe("Certificate", func() {
 	Describe("[Unit]", func() {
@@ -47,20 +39,20 @@ var _ = Describe("Certificate", func() {
 				Expect(err).NotTo(HaveOccurred())
 				// Expect(cer.Leaf).NotTo(BeNil())
 				// Expect(cer.Leaf.VerifyHostname("APNS/2 Development IOS Push Services: com.sideshow.Apns2")).To(BeNil())
-				Expect(verifyHostname(cer)).To(BeNil())
+				Expect(cer).To(Not(Equal(tls.Certificate{})))
 			})
 
 			It("Should load valid certificate from P12Bytes", func() {
 				bytes, _ := ioutil.ReadFile("../tls/_fixtures/certificate-valid.p12")
 				cer, err := FromP12Bytes(bytes, "")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(verifyHostname(cer)).To(BeNil())
+				Expect(cer).To(Not(Equal(tls.Certificate{})))
 			})
 
 			It("Should load encrypted certificate from P12File", func() {
 				cer, err := FromP12File("../tls/_fixtures/certificate-valid-encrypted.p12", "password")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(verifyHostname(cer)).To(BeNil())
+				Expect(cer).To(Not(Equal(tls.Certificate{})))
 			})
 
 			It("Should fail if there is no P12File", func() {
@@ -80,20 +72,20 @@ var _ = Describe("Certificate", func() {
 			It("Should load valid certificate from PemFile", func() {
 				cer, err := FromPemFile("../tls/_fixtures/certificate-valid.pem", "")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(verifyHostname(cer)).To(BeNil())
+				Expect(cer).To(Not(Equal(tls.Certificate{})))
 			})
 
 			It("Should load valid certificate from PemBytes", func() {
 				bytes, _ := ioutil.ReadFile("../tls/_fixtures/certificate-valid.pem")
 				cer, err := FromPemBytes(bytes, "")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(verifyHostname(cer)).To(BeNil())
+				Expect(cer).To(Not(Equal(tls.Certificate{})))
 			})
 
 			It("Should load encrypted certificate from PemFile", func() {
 				cer, err := FromPemFile("../tls/_fixtures/certificate-valid-encrypted.pem", "password")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(verifyHostname(cer)).To(BeNil())
+				Expect(cer).To(Not(Equal(tls.Certificate{})))
 			})
 
 			It("Should fail if there is no PemFile", func() {

--- a/extensions/apns_message_handler_test.go
+++ b/extensions/apns_message_handler_test.go
@@ -46,7 +46,6 @@ var _ = FDescribe("APNS Message Handler", func() {
 	var feedbackClients []interfaces.FeedbackReporter
 	var handler *APNSMessageHandler
 	var invalidTokenHandlers []interfaces.InvalidTokenHandler
-	var mockKafkaConsumerClient *mocks.KafkaConsumerClientMock
 	var mockKafkaProducerClient *mocks.KafkaProducerClientMock
 	var mockPushQueue *mocks.APNSPushQueueMock
 	var mockStatsDClient *mocks.StatsDClientMock
@@ -67,7 +66,6 @@ var _ = FDescribe("APNS Message Handler", func() {
 		BeforeEach(func() {
 			mockStatsDClient = mocks.NewStatsDClientMock()
 			mockKafkaProducerClient = mocks.NewKafkaProducerClientMock()
-			mockKafkaConsumerClient = mocks.NewKafkaConsumerClientMock()
 			mockKafkaProducerClient.StartConsumingMessagesInProduceChannel()
 			c, err := NewStatsD(config, logger, mockStatsDClient)
 			Expect(err).NotTo(HaveOccurred())

--- a/extensions/gcm_message_handler_test.go
+++ b/extensions/gcm_message_handler_test.go
@@ -45,7 +45,6 @@ var _ = Describe("GCM Message Handler", func() {
 	var invalidTokenHandlers []interfaces.InvalidTokenHandler
 	var mockClient *mocks.GCMClientMock
 	var mockDb *mocks.PGMock
-	var mockKafkaConsumerClient *mocks.KafkaConsumerClientMock
 	var mockKafkaProducerClient *mocks.KafkaProducerClientMock
 	var mockStatsDClient *mocks.StatsDClientMock
 	var statsClients []interfaces.StatsReporter
@@ -65,7 +64,6 @@ var _ = Describe("GCM Message Handler", func() {
 			mockStatsDClient = mocks.NewStatsDClientMock()
 			mockKafkaProducerClient = mocks.NewKafkaProducerClientMock()
 			mockKafkaProducerClient.StartConsumingMessagesInProduceChannel()
-			mockKafkaConsumerClient = mocks.NewKafkaConsumerClientMock()
 			c, err := NewStatsD(config, logger, mockStatsDClient)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
This PR:

* Fixes the certificate tests that was breaking due to an updated introduced in go1.11 that changed the behaviour of the `VerifyHostNameFunction` (https://tip.golang.org/doc/go1.11#crypto/x509). The fix is based on a commit done in the [sideshow/apns2](https://github.com/sideshow/apns2/commit/656cc74772a0d81eb4f6da2c2994ea2c7a830d6e)  repo which the original code was based on. 

* Removed declared but not used variables in `apns_message_handler.go` and `gcm_message_handler.go` that were preventing the tests from running.

* Update the Gokpkg.lock file with fields introduced in dep v0.5.0 (https://golang.github.io/dep/blog/2018/07/25/announce-v0.5.0.html)

