### PR TITLE
Asynchronous Invalid Token Handlers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -312,24 +312,6 @@
   version = "v1.3"
 
 [[projects]]
-  digest = "1:1aa50e504ff54351992a2324a4aba36f8eaa9ff34308ffa6a610a8dc188332b5"
-  name = "github.com/topfreegames/pusher"
-  packages = [
-    "cmd",
-    "errors",
-    "extensions",
-    "interfaces",
-    "mocks",
-    "pusher",
-    "structs",
-    "testing",
-    "util",
-  ]
-  pruneopts = ""
-  revision = "7239579ceed0c5d4ae13af66a5e1ece9e8ccf5bd"
-  version = "3.4.2"
-
-[[projects]]
   branch = "master"
   digest = "1:1710f8497e287491a719f21eb51b1068b224c63d31084b3d7121c6d65bc3bebf"
   name = "golang.org/x/crypto"
@@ -439,15 +421,6 @@
     "github.com/spf13/cobra",
     "github.com/spf13/viper",
     "github.com/topfreegames/go-gcm",
-    "github.com/topfreegames/pusher/cmd",
-    "github.com/topfreegames/pusher/errors",
-    "github.com/topfreegames/pusher/extensions",
-    "github.com/topfreegames/pusher/interfaces",
-    "github.com/topfreegames/pusher/mocks",
-    "github.com/topfreegames/pusher/pusher",
-    "github.com/topfreegames/pusher/structs",
-    "github.com/topfreegames/pusher/testing",
-    "github.com/topfreegames/pusher/util",
     "golang.org/x/crypto/pkcs12",
     "gopkg.in/pg.v5",
     "gopkg.in/pg.v5/types",

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -57,3 +57,4 @@ invalidToken:
     maxRetries: 3
     database: push
     connectionTimeout: 100
+    chanSize: 1000

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -59,3 +59,4 @@ invalidToken:
     maxRetries: 3
     database: push
     connectionTimeout: 100
+    chanSize: 1000

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -47,6 +47,7 @@ If Pusher needs to connect to a PostgreSQL database in order to delete invalid t
 * `PUSHER_INVALIDTOKEN_PG_POOLSIZE` - PostgreSQL connection pool size;
 * `PUSHER_INVALIDTOKEN_PG_MAXRETRIES` - PostgreSQL connection max retries;
 * `PUSHER_INVALIDTOKEN_PG_CONNECTIONTIMEOUT` - Timeout for trying to establish connection;
+* `PUSHER_INVALIDTOKEN_PG_CHANSIZE` - Size of the channel to buffer the tokens to be deleted;
 
 Other than that, there are a couple more configurations you can pass using environment variables:
 

--- a/extensions/apns_message_handler_test.go
+++ b/extensions/apns_message_handler_test.go
@@ -133,7 +133,8 @@ var _ = FDescribe("APNS Message Handler", func() {
 				handler.handleAPNSResponse(res)
 				Expect(handler.responsesReceived).To(Equal(int64(1)))
 				Expect(handler.failuresReceived).To(Equal(int64(1)))
-				Expect(hook.Entries).To(ContainLogMessage("deleting token"))
+				Eventually(func() []*logrus.Entry { return hook.Entries }).
+					Should(ContainLogMessage("deleting token"))
 				//Expect(hook.Entries[len(hook.Entries)-2].Data["category"]).To(Equal("TokenError"))
 			})
 
@@ -146,7 +147,8 @@ var _ = FDescribe("APNS Message Handler", func() {
 				handler.handleAPNSResponse(res)
 				Expect(handler.responsesReceived).To(Equal(int64(1)))
 				Expect(handler.failuresReceived).To(Equal(int64(1)))
-				Expect(hook.Entries).To(ContainLogMessage("deleting token"))
+				Eventually(func() []*logrus.Entry { return hook.Entries }).
+					Should(ContainLogMessage("deleting token"))
 				//Expect(hook.Entries[len(hook.Entries)-2].Data["category"]).To(Equal("TokenError"))
 			})
 

--- a/extensions/common.go
+++ b/extensions/common.go
@@ -46,6 +46,9 @@ func handleInvalidToken(invalidTokenHandlers []interfaces.InvalidTokenHandler, t
 	}
 }
 
+// StopInvalidTokenHandlers stops the invalid token handlers
+// For each handler, it waits its buffered queue to be completely empty and forces
+// the termination after the given timeout
 func StopInvalidTokenHandlers(
 	logger *log.Logger,
 	invalidTokenHandlers []interfaces.InvalidTokenHandler,

--- a/extensions/common.go
+++ b/extensions/common.go
@@ -120,3 +120,9 @@ func statsReporterHandleNotificationFailure(statsReporters []interfaces.StatsRep
 		statsReporter.HandleNotificationFailure(game, platform, err)
 	}
 }
+
+func statsReporterReportMetricIncrement(statsReporters []interfaces.StatsReporter, metric string, game string, platform string) {
+	for _, statsReporter := range statsReporters {
+		statsReporter.ReportMetricIncrement(metric, game, platform)
+	}
+}

--- a/extensions/datadog_statsd.go
+++ b/extensions/datadog_statsd.go
@@ -117,6 +117,20 @@ func (s *StatsD) ReportGoStats(
 	s.Client.Gauge("next_gc_bytes", float64(nextGCBytes), tags, 1)
 }
 
+// ReportMetricIncrement reports a custom metric increment in statsd
+func (s *StatsD) ReportMetricIncrement(
+	metric string,
+	game, platform string,
+) {
+	hostname, _ := os.Hostname()
+	tags := []string{
+		fmt.Sprintf("hostname:%s", hostname),
+		fmt.Sprintf("game:%s", game),
+		fmt.Sprintf("platform:%s", platform),
+	}
+	s.Client.Incr(metric, tags, 1)
+}
+
 //Cleanup closes statsd connection
 func (s *StatsD) Cleanup() error {
 	s.Client.Close()

--- a/extensions/datadog_statsd_test.go
+++ b/extensions/datadog_statsd_test.go
@@ -99,6 +99,27 @@ var _ = Describe("StatsD Extension", func() {
 				Expect(mockClient.Count["failed"]).To(Equal(2))
 			})
 		})
+
+		Describe("Reporting metric increment", func() {
+			It("should report metric increment in statsd", func() {
+				statsd, err := NewStatsD(config, logger, mockClient)
+				Expect(err).NotTo(HaveOccurred())
+				defer statsd.Cleanup()
+
+				statsd.ReportMetricIncrement("tokens_to_delete", "game", "apns")
+				statsd.ReportMetricIncrement("tokens_to_delete", "game", "apns")
+				statsd.ReportMetricIncrement("tokens_to_delete", "game", "apns")
+
+				statsd.ReportMetricIncrement("tokens_deleted", "game", "apns")
+				statsd.ReportMetricIncrement("tokens_deleted", "game", "apns")
+
+				statsd.ReportMetricIncrement("tokens_deletion_failed", "game", "apns")
+
+				Expect(mockClient.Count["tokens_to_delete"]).To(Equal(3))
+				Expect(mockClient.Count["tokens_deleted"]).To(Equal(2))
+				Expect(mockClient.Count["tokens_deletion_failed"]).To(Equal(1))
+			})
+		})
 	})
 
 	Describe("[Integration]", func() {

--- a/extensions/gcm_message_handler_test.go
+++ b/extensions/gcm_message_handler_test.go
@@ -73,7 +73,7 @@ var _ = Describe("GCM Message Handler", func() {
 			feedbackClients = []interfaces.FeedbackReporter{kc}
 
 			mockDb = mocks.NewPGMock(0, 1)
-			it, err := NewTokenPG(config, logger, mockDb)
+			it, err := NewTokenPG(config, logger, statsClients, mockDb)
 			Expect(err).NotTo(HaveOccurred())
 			invalidTokenHandlers = []interfaces.InvalidTokenHandler{it}
 
@@ -135,6 +135,10 @@ var _ = Describe("GCM Message Handler", func() {
 				Expect(handler.failuresReceived).To(Equal(int64(1)))
 				Eventually(func() []*logrus.Entry { return hook.Entries }).
 					Should(ContainLogMessage("deleting token"))
+
+				Expect(mockStatsDClient.Count[MetricsTokensToDelete]).To(Equal(1))
+				Eventually(func() int { return mockStatsDClient.Count[MetricsTokensDeleted] }).
+					Should(Equal(1))
 			})
 
 			It("if response has error BAD_REGISTRATION", func() {
@@ -146,6 +150,10 @@ var _ = Describe("GCM Message Handler", func() {
 				Expect(handler.failuresReceived).To(Equal(int64(1)))
 				Eventually(func() []*logrus.Entry { return hook.Entries }).
 					Should(ContainLogMessage("deleting token"))
+
+				Expect(mockStatsDClient.Count[MetricsTokensToDelete]).To(Equal(1))
+				Eventually(func() int { return mockStatsDClient.Count[MetricsTokensDeleted] }).
+					Should(Equal(1))
 			})
 
 			It("if response has error INVALID_JSON", func() {
@@ -509,7 +517,7 @@ var _ = Describe("GCM Message Handler", func() {
 				feedbackClients = []interfaces.FeedbackReporter{kc}
 
 				mockClient = mocks.NewGCMClientMock()
-				it, err := NewTokenPG(config, logger, mockDb)
+				it, err := NewTokenPG(config, logger, statsClients, mockDb)
 				Expect(err).NotTo(HaveOccurred())
 				invalidTokenHandlers = []interfaces.InvalidTokenHandler{it}
 

--- a/extensions/gcm_message_handler_test.go
+++ b/extensions/gcm_message_handler_test.go
@@ -32,7 +32,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
-	"github.com/topfreegames/go-gcm"
+	gcm "github.com/topfreegames/go-gcm"
 	"github.com/topfreegames/pusher/interfaces"
 	"github.com/topfreegames/pusher/mocks"
 	. "github.com/topfreegames/pusher/testing"
@@ -133,7 +133,8 @@ var _ = Describe("GCM Message Handler", func() {
 				handler.handleGCMResponse(res)
 				Expect(handler.responsesReceived).To(Equal(int64(1)))
 				Expect(handler.failuresReceived).To(Equal(int64(1)))
-				Expect(hook.Entries).To(ContainLogMessage("deleting token"))
+				Eventually(func() []*logrus.Entry { return hook.Entries }).
+					Should(ContainLogMessage("deleting token"))
 			})
 
 			It("if response has error BAD_REGISTRATION", func() {
@@ -143,7 +144,8 @@ var _ = Describe("GCM Message Handler", func() {
 				handler.handleGCMResponse(res)
 				Expect(handler.responsesReceived).To(Equal(int64(1)))
 				Expect(handler.failuresReceived).To(Equal(int64(1)))
-				Expect(hook.Entries).To(ContainLogMessage("deleting token"))
+				Eventually(func() []*logrus.Entry { return hook.Entries }).
+					Should(ContainLogMessage("deleting token"))
 			})
 
 			It("if response has error INVALID_JSON", func() {
@@ -214,9 +216,9 @@ var _ = Describe("GCM Message Handler", func() {
 					gcm.XMPPMessage{
 						TimeToLive:               &ttl,
 						DeliveryReceiptRequested: false,
-						DryRun: true,
-						To:     uuid.NewV4().String(),
-						Data:   map[string]interface{}{},
+						DryRun:                   true,
+						To:                       uuid.NewV4().String(),
+						Data:                     map[string]interface{}{},
 					},
 					metadata,
 					makeTimestamp() + int64(1000000),
@@ -245,9 +247,9 @@ var _ = Describe("GCM Message Handler", func() {
 					gcm.XMPPMessage{
 						TimeToLive:               &ttl,
 						DeliveryReceiptRequested: false,
-						DryRun: true,
-						To:     uuid.NewV4().String(),
-						Data:   map[string]interface{}{},
+						DryRun:                   true,
+						To:                       uuid.NewV4().String(),
+						Data:                     map[string]interface{}{},
 					},
 					metadata,
 					makeTimestamp() - int64(100),
@@ -285,9 +287,9 @@ var _ = Describe("GCM Message Handler", func() {
 				msg := &gcm.XMPPMessage{
 					TimeToLive:               &ttl,
 					DeliveryReceiptRequested: false,
-					DryRun: true,
-					To:     uuid.NewV4().String(),
-					Data:   map[string]interface{}{},
+					DryRun:                   true,
+					To:                       uuid.NewV4().String(),
+					Data:                     map[string]interface{}{},
 				}
 				msgBytes, err := json.Marshal(msg)
 				Expect(err).NotTo(HaveOccurred())
@@ -315,9 +317,9 @@ var _ = Describe("GCM Message Handler", func() {
 					gcm.XMPPMessage{
 						TimeToLive:               &ttl,
 						DeliveryReceiptRequested: false,
-						DryRun: true,
-						To:     uuid.NewV4().String(),
-						Data:   map[string]interface{}{},
+						DryRun:                   true,
+						To:                       uuid.NewV4().String(),
+						Data:                     map[string]interface{}{},
 					},
 					metadata,
 					makeTimestamp() + int64(1000000),
@@ -341,9 +343,9 @@ var _ = Describe("GCM Message Handler", func() {
 				msg := &gcm.XMPPMessage{
 					TimeToLive:               &ttl,
 					DeliveryReceiptRequested: false,
-					DryRun: true,
-					To:     uuid.NewV4().String(),
-					Data:   map[string]interface{}{},
+					DryRun:                   true,
+					To:                       uuid.NewV4().String(),
+					Data:                     map[string]interface{}{},
 				}
 				msgBytes, err := json.Marshal(msg)
 				Expect(err).NotTo(HaveOccurred())
@@ -460,9 +462,9 @@ var _ = Describe("GCM Message Handler", func() {
 				msg := &gcm.XMPPMessage{
 					TimeToLive:               &ttl,
 					DeliveryReceiptRequested: false,
-					DryRun: true,
-					To:     uuid.NewV4().String(),
-					Data:   map[string]interface{}{},
+					DryRun:                   true,
+					To:                       uuid.NewV4().String(),
+					Data:                     map[string]interface{}{},
 				}
 				msgBytes, err := json.Marshal(msg)
 				Expect(err).NotTo(HaveOccurred())

--- a/interfaces/invalid_token_handler.go
+++ b/interfaces/invalid_token_handler.go
@@ -25,4 +25,6 @@ package interfaces
 // InvalidTokenHandler interface for defining functions that handle invalid tokens easily pluggable
 type InvalidTokenHandler interface {
 	HandleToken(token string, game string, platform string) error
+	HasJob() bool
+	Stop() error
 }

--- a/interfaces/stats_reporter.go
+++ b/interfaces/stats_reporter.go
@@ -30,4 +30,5 @@ type StatsReporter interface {
 	HandleNotificationSuccess(game string, platform string)
 	HandleNotificationFailure(game string, platform string, err *errors.PushError)
 	ReportGoStats(numGoRoutines int, allocatedAndNotFreed, heapObjects, nextGCBytes, pauseGCNano uint64)
+	ReportMetricIncrement(metric string, game, platform string)
 }

--- a/pusher/apns.go
+++ b/pusher/apns.go
@@ -160,7 +160,7 @@ func (a *APNSPusher) configureStatsReporters(clientOrNil interfaces.StatsDClient
 }
 
 func (a *APNSPusher) configureInvalidTokenHandlers(dbOrNil interfaces.DB) error {
-	invalidTokenHandlers, err := configureInvalidTokenHandlers(a.Config, a.Logger, dbOrNil)
+	invalidTokenHandlers, err := configureInvalidTokenHandlers(a.Config, a.Logger, a.StatsReporters, dbOrNil)
 	if err != nil {
 		return err
 	}

--- a/pusher/apns.go
+++ b/pusher/apns.go
@@ -217,6 +217,7 @@ func (a *APNSPusher) Start() {
 	}
 	a.Queue.StopConsuming()
 	GracefulShutdown(a.Queue.PendingMessagesWaitGroup(), time.Duration(a.GracefulShutdownTimeout)*time.Second)
+	extensions.StopInvalidTokenHandlers(a.Logger, a.InvalidTokenHandlers, time.Duration(a.GracefulShutdownTimeout)*time.Second)
 }
 
 func (a *APNSPusher) reportGoStats() {

--- a/pusher/gcm.go
+++ b/pusher/gcm.go
@@ -154,7 +154,7 @@ func (g *GCMPusher) configureFeedbackReporters() error {
 }
 
 func (g *GCMPusher) configureInvalidTokenHandlers(dbOrNil interfaces.DB) error {
-	invalidTokenHandlers, err := configureInvalidTokenHandlers(g.Config, g.Logger, dbOrNil)
+	invalidTokenHandlers, err := configureInvalidTokenHandlers(g.Config, g.Logger, g.StatsReporters, dbOrNil)
 	if err != nil {
 		return err
 	}

--- a/pusher/gcm.go
+++ b/pusher/gcm.go
@@ -211,6 +211,7 @@ func (g *GCMPusher) Start() {
 	}
 	g.Queue.StopConsuming()
 	GracefulShutdown(g.Queue.PendingMessagesWaitGroup(), time.Duration(g.GracefulShutdownTimeout)*time.Second)
+	extensions.StopInvalidTokenHandlers(g.Logger, g.InvalidTokenHandlers, time.Duration(g.GracefulShutdownTimeout)*time.Second)
 }
 
 func (g *GCMPusher) reportGoStats() {

--- a/pusher/handlers.go
+++ b/pusher/handlers.go
@@ -31,16 +31,16 @@ import (
 	"github.com/topfreegames/pusher/interfaces"
 )
 
-type invalidTokenHandlerInitializer func(*viper.Viper, *logrus.Logger, interfaces.DB) (interfaces.InvalidTokenHandler, error)
+type invalidTokenHandlerInitializer func(*viper.Viper, *logrus.Logger, []interfaces.StatsReporter, interfaces.DB) (interfaces.InvalidTokenHandler, error)
 
 // AvailableInvalidTokenHandlers contains functions to initialize all invalid token handlers
 var AvailableInvalidTokenHandlers = map[string]invalidTokenHandlerInitializer{
-	"pg": func(config *viper.Viper, logger *logrus.Logger, dbOrNil interfaces.DB) (interfaces.InvalidTokenHandler, error) {
-		return extensions.NewTokenPG(config, logger, dbOrNil)
+	"pg": func(config *viper.Viper, logger *logrus.Logger, statsReporter []interfaces.StatsReporter, dbOrNil interfaces.DB) (interfaces.InvalidTokenHandler, error) {
+		return extensions.NewTokenPG(config, logger, statsReporter, dbOrNil)
 	},
 }
 
-func configureInvalidTokenHandlers(config *viper.Viper, logger *logrus.Logger, dbOrNil interfaces.DB) ([]interfaces.InvalidTokenHandler, error) {
+func configureInvalidTokenHandlers(config *viper.Viper, logger *logrus.Logger, statsReporter []interfaces.StatsReporter, dbOrNil interfaces.DB) ([]interfaces.InvalidTokenHandler, error) {
 	invalidTokenHandlers := []interfaces.InvalidTokenHandler{}
 	invalidTokenHandlerNames := config.GetStringSlice("invalidToken.handlers")
 	for _, invalidTokenHandlerName := range invalidTokenHandlerNames {
@@ -49,7 +49,7 @@ func configureInvalidTokenHandlers(config *viper.Viper, logger *logrus.Logger, d
 			return nil, fmt.Errorf("Failed to initialize %s. Invalid Token Handler not available.", invalidTokenHandlerName)
 		}
 
-		r, err := invalidTokenHandlerFunc(config, logger, dbOrNil)
+		r, err := invalidTokenHandlerFunc(config, logger, statsReporter, dbOrNil)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to initialize %s. %s", invalidTokenHandlerName, err.Error())
 		}


### PR DESCRIPTION
We want to make the TokenPG an asynchronous component by being able to handle the invalid tokens deletion in a separate go routine. By doing so, we assure that the pushing in GCM and APNS won’t be impacted by this operation.

Two new methods were introduced in `InvalidTokenHandler` interface in order to enable the handler gracefully shutdown: 
* `HasJob`, to verify if there’s still token in the pipeline to be processed
* `Stop` to stops the handler asynchronous worker

The TokenPG was modified in order to use a go channel to pass the invalid tokens to a worker. Its buffer size can be modified using the new env var `INVALIDTOKEN_PG_CHANSIZE`. The worked is started during the TokenPG creation and stopped by the `Stop` function. 

Once the `Stop` method is called, no more tokens can be sent using the `HandleToken` method. To avoid that unprocessed tokens remain in the queue, the client might check the queue size by using `HasJob` before stopping the handler.

Since `HandleToken` just put a token in the processing queue, it doesn’t return if there’s an error during the token deletion anymore. This should be check by analysing the log messages.

This PR also introduces the following updates:

## Extensions
* Update `APNSMessageHandler`, `GCMMessageHandler`, `TokenPG` and `common` tests to check for async log messages since `HandleToken` doesn’t return a deletion error.
* Create tests to check the handler stopping process
* Create `StopInvalidTokenHandlers` auxiliary function to gracefully shutdown Invalid Token Handlers. We check the Handler during a period of time before stop it. After this time, we force its completion even though there’s still tokens to be processed. Tests were also introduce to check this logic.

## Pusher
* Use the `StopInvalidTokenHandlers` auxiliary function to gracefully shutdown the handlers while stopping the `APNS` and `GCM` Pushers

