### PR TITLE
Environment Variable to Control Broker Routing

### DIFF
--- a/feedback/broker_test.go
+++ b/feedback/broker_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Broker", func() {
 		inChan = make(chan QueueMessage, 100)
 	})
 
-	Describe("[Unit]", func() {
+	Describe("[Unit]Broker", func() {
 		It("Should start and stop correctly", func() {
 			broker, err := NewBroker(logger, config, nil, inChan, nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -114,6 +114,26 @@ var _ = Describe("Broker", func() {
 					Expect(len(broker.InChan)).To(Equal(0))
 					Expect(len(broker.InvalidTokenOutChan)).To(Equal(0))
 				})
+
+				It("Should not route if invalid token is disabled", func() {
+					config.Set("feedbackListeners.broker.invalidTokenEnabled", false)
+
+					broker, err := NewBroker(logger, config, nil, inChan, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					broker.Start()
+					inChan <- kafkaMsg
+
+					Eventually(func() int {
+						return len(broker.InChan)
+					}).Should(Equal(0))
+
+					Consistently(func() int {
+						return len(broker.InvalidTokenOutChan)
+					}).Should(Equal(0))
+
+					broker.Stop()
+				})
 			})
 		})
 
@@ -158,6 +178,26 @@ var _ = Describe("Broker", func() {
 					broker.Stop()
 					Expect(len(broker.InChan)).To(Equal(0))
 					Expect(len(broker.InvalidTokenOutChan)).To(Equal(0))
+				})
+
+				It("Should not route if invalid token is disabled", func() {
+					config.Set("feedbackListeners.broker.invalidTokenEnabled", false)
+
+					broker, err := NewBroker(logger, config, nil, inChan, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					broker.Start()
+					inChan <- kafkaMsg
+
+					Eventually(func() int {
+						return len(broker.InChan)
+					}).Should(Equal(0))
+
+					Consistently(func() int {
+						return len(broker.InvalidTokenOutChan)
+					}).Should(Equal(0))
+
+					broker.Stop()
 				})
 			})
 		})

--- a/feedback/listener.go
+++ b/feedback/listener.go
@@ -131,6 +131,9 @@ func (l *Listener) Start() {
 	l.Broker.Start()
 	l.InvalidTokenHandler.Start()
 
+	statsReporterReportMetricCount(l.StatsReporters,
+		"feedback_listener_restart", 1, "", "")
+
 	sigchan := make(chan os.Signal)
 	signal.Notify(sigchan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 


### PR DESCRIPTION
This PR introduces a new environment variable to enable/disable the broker routing to the Invalid Token Channel.

It also sends a new metric every time the listener is restarted.