### PR TITLE
Speed up APNS client

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,8 +1,8 @@
 ---
 gracefulShutdownTimeout: 30
 apns:
-  concurrentWorkers: 100
-  connectionPoolSize: 10
+  concurrentWorkers: 300
+  connectionPoolSize: 1
   logStatsInterval: 10000
   apps: "game"
   certs:

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -1,8 +1,8 @@
 ---
 gracefulShutdownTimeout: 10
 apns:
-  concurrentWorkers: 100
-  connectionPoolSize: 10
+  concurrentWorkers: 300
+  connectionPoolSize: 1
   logStatsInterval: 750
   apps: "game"
   certs:

--- a/extensions/apns_push_queue.go
+++ b/extensions/apns_push_queue.go
@@ -121,8 +121,9 @@ func (p *APNSPushQueue) pushWorker() {
 
 	for notification := range p.pushChannel {
 		client := <-p.clients
-		res, err := client.Push(notification)
 		p.clients <- client
+
+		res, err := client.Push(notification)
 		if err != nil {
 			l.WithError(err).Error("push error")
 		}
@@ -137,6 +138,7 @@ func (p *APNSPushQueue) pushWorker() {
 			DeviceToken: notification.DeviceToken,
 		}
 		p.responseChannel <- newRes
+
 	}
 }
 


### PR DESCRIPTION
The apns2 client can support multiple pushes simultaneously. 

Changes based on this [link](https://github.com/sideshow/apns2/wiki/APNS-HTTP-2-Push-Speed).