### PR TITLE
Fix init nil pointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ vendor/
 *.swp
 *.swo
 .*swp
+
+.idea

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -313,17 +313,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1710f8497e287491a719f21eb51b1068b224c63d31084b3d7121c6d65bc3bebf"
-  name = "golang.org/x/crypto"
-  packages = [
-    "pkcs12",
-    "pkcs12/internal/rc2",
-  ]
-  pruneopts = ""
-  revision = "6914964337150723782436d56b3f21610a74ce7b"
-
-[[projects]]
-  branch = "master"
   digest = "1:3246e12ee1c5003acebbc8ceea757df86cfc23f7a321d70d47f96b9b21462115"
   name = "golang.org/x/net"
   packages = [
@@ -421,7 +410,6 @@
     "github.com/spf13/cobra",
     "github.com/spf13/viper",
     "github.com/topfreegames/go-gcm",
-    "golang.org/x/crypto/pkcs12",
     "gopkg.in/pg.v5",
     "gopkg.in/pg.v5/types",
   ]

--- a/pusher/apns.go
+++ b/pusher/apns.go
@@ -119,10 +119,10 @@ func (a *APNSPusher) configure(queue interfaces.APNSPushQueue, db interfaces.DB,
 			for _, statsReporter := range a.StatsReporters {
 				statsReporter.InitializeFailure(k, "apns")
 			}
-			l.WithFields(logrus.Fields{
+			l.WithError(err).WithFields(logrus.Fields{
 				"method": "apns",
 				"game":   k,
-			}).Error(err)
+			}).Error("failed to initialize apns handler")
 		}
 	}
 	if len(a.MessageHandler) == 0 {

--- a/pusher/apns_test.go
+++ b/pusher/apns_test.go
@@ -92,11 +92,32 @@ var _ = Describe("APNS Pusher", func() {
 					mockPushQueue,
 				)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(len(pusher.MessageHandler)).To(Equal(1))
 				Expect(pusher).NotTo(BeNil())
 				defer func() { pusher.run = false }()
 				go pusher.Start()
 				time.Sleep(50 * time.Millisecond)
 			})
+
+			It("should ignore failed handlers", func() {
+				config.Set("apns.apps", "game,invalidgame")
+				config.Set("apns.certs.invalidgame.authKeyPath", "../tls/authkey_invalid.p8")
+				config.Set("apns.certs.invalidgame.keyID", "oiejowijefiowejf")
+				config.Set("apns.certs.invalidgame.teamID", "aoijeoijfiowejfoij")
+				config.Set("apns.certs.invalidgame.teamID", "com.invalidgame.test")
+
+				pusher, err := NewAPNSPusher(
+					isProduction,
+					config,
+					logger,
+					mockStatsDClient,
+					mockDb,
+					mockPushQueue,
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pusher.MessageHandler).To(HaveLen(1))
+			})
 		})
+
 	})
 })

--- a/pusher/gcm.go
+++ b/pusher/gcm.go
@@ -112,10 +112,10 @@ func (g *GCMPusher) configure(client interfaces.GCMClient, db interfaces.DB, sta
 			for _, statsReporter := range g.StatsReporters {
 				statsReporter.InitializeFailure(k, "gcm")
 			}
-			l.WithFields(logrus.Fields{
+			l.WithError(err).WithFields(logrus.Fields{
 				"method": "gcm",
 				"game":   k,
-			}).Error(err)
+			}).Error("failed to initialize gcm handler")
 		}
 	}
 	if len(g.MessageHandler) == 0 {


### PR DESCRIPTION
If one of the games failed initialization for either GCM or APNS, it would be included in the MessageHandler map anyways. This would eventually crash on initialization when the app would try to access one of these nil pointers.

I added a test on APNS, since it was easier to implement. On GCM I needed to find some valid keys for testing, and this was not present in the repository.