### PR TITLE
Remove jenkins trigger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ services:
 - docker
 sudo: true
 env:
-  matrix:
   - LIBRDKAFKA_VERSION=v0.11.5
-  global:
-    secure: dm9+XwwQk759cpVpleBjHhtbbe5s3LNjz9wwMGa3DEENFAMiX4HjJSmfyvV8D3t0NdicDJrYW4HdTIqacneIOFbkMEYA4RmwdxBe4NcJQC6es/8I+EL52/EKmwKwtnkvsQFrQkJmzS1JYKNQb73bWY4huTGNxYiUiX9xfK3sO+X9xi62eN/xpOVaSbIwB44h5oNEj7/aaeQEvsqg69eO5hRsCdIRWXxTyP37GdMupC4vtE6A5uU8LdGzE4f0dP5JKxmL53s0fCM0kqjP1ycIOwjhlqWdo+BjRBAKpE8cM4p/BnzM+rCWNyjt333Kxjwp42FBnfaYiEET1f0xN43h2rfZRHvCoL3ATGev2aDzGMhsOuqHLfVRFt7u/9QynZltApctsmEMMYXDY6a9TsbcE6UjC7GG4HTIOO/PmWyburL18aTicCWLUvbKhljG7873sAwZchrtCxXxyBkd6zjHznciwljbVvexMlWhaO269C++u95fdEUO2pkidDNkrnf5TjYJnGJGcyBvXAvkGdZrxiOwV3pxH1mfb7D87tvzo60XRf3/7++Un8iggFb9+Ppd35eYCnpNmEP95IhKigkJ6hMY5Al8ARpQ+JA6EwTqMPZf+r5RiAq4uxOeYK0rEiWDY7RxqlPPW7AGdoyy/OJ1LgbCdZssZs+Ig4JWViwdTWg=
 cache:
   directories:
   - "$HOME/.cache/librdkafka"
@@ -23,4 +20,4 @@ script:
 - make test
 after_success:
 - "$HOME/gopath/bin/goveralls -coverprofile ./_build/test-coverage-all.out -service=travis-ci"
-- "./push_to_docker.sh && ./success_webhook.sh"
+- "./push_to_docker.sh"

--- a/success_webhook.sh
+++ b/success_webhook.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-if [ "$TRAVIS_BRANCH" = "master" ] && [ "$LIBRDKAFKA_VERSION" != "master" ]; then
-  VERSION=$(cat ./util/version.go | grep "var Version" | awk ' { print $4 } ' | sed s/\"//g)
-  curl -X POST "$FARM_URL$VERSION.$TRAVIS_BUILD_NUMBER"
-fi

--- a/util/version.go
+++ b/util/version.go
@@ -23,4 +23,4 @@
 package util
 
 //Version is the current version of pusher.
-var Version = "3.5.0"
+var Version = "3.5.1"


### PR DESCRIPTION
Removing jenkins trigger because now we are using flux to manage image updates in our internal repo.