### PR TITLE
ci: publish docker images when specific tags are pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   release:
     types:
       - published
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0.9]+-[abcehlprt]+.?[0-9]?[0-9]?
 jobs:
   push_to_registry:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Publish Docker images when specific tags are pushed, allowing to test alpha, beta and release candidate versions without publishing a release.

The tag [pattern](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) is `v[0-9]+.[0-9]+.[0.9]+-[abcehlprt]+.?[0-9]?[0-9]?`. List of examples of valid tags:
* v1.0.0-alpha
* v999.999.999-beta.99
* v0.0.1-rc.1
* v666.666.666-ratabaratacapacha.00