### PR TITLE
ci: publish docker images when specific tags are pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,10 @@ on:
       - published
   push:
     tags:
-      - v[0-9]+.[0-9]+.[0.9]+-[abcehlprt]+.?[0-9]?[0-9]?
+      - 'v[0-9]+.[0-9]+.[0-9]+-[abcehlprt]+.?[0-9]?[0-9]?'
 jobs:
   push_to_registry:
+    name: Publish Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,6 +1,8 @@
 name: Build, Unit Tests and Linter
 on:
   push:
+    branches:
+      - '**'
     paths:
       - '**.go'
       - 'Gopkg.lock'


### PR DESCRIPTION
Related to #40

I have not seen [this](https://github.com/topfreegames/pusher/actions/runs/3832883306) problem. There was a problem in the tag pattern, instead of using `[0-9]`, it had a `[0.9]`.

Publish Docker images when specific tags are pushed, allowing to test alpha, beta and release candidate versions without publishing a release.

The tag [pattern](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) is `v[0-9]+.[0-9]+.[0-9]+-[abcehlprt]+.?[0-9]?[0-9]?`. List of examples of valid tags:
* v1.0.0-alpha
* v999.999.999-beta.99
* v0.0.1-rc.1
* v666.666.666-ratabaratacapacha.00