### PR TITLE
cd: add timestamp label to images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,28 @@ on:
       - published
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+-[abcehlprt]+.?[0-9]?[0-9]?'
+      - '[0-9]+.[0-9]+.[0-9]+'
 jobs:
   push_to_registry:
     name: Publish Docker Image
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: tfgco/pusher
-          tag_with_ref: true
+      - name: Get Timestamp
+        id: get_timestamp
+        run: |
+          echo "ISO_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+      - name: Build and Push to Docker Hub
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: tfgco/pusher:${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.get_timestamp.outputs.ISO_TIMESTAMP }}
+            org.label-schema.build-date=${{ steps.get_timestamp.outputs.ISO_TIMESTAMP }}


### PR DESCRIPTION
The goal is to provide means for FluxCD to know tag timestamps other then the usual command:
```
docker inspect -f '{{ .Metadata.LastTagTime }}' somerep:tag
```

According to [FluxCD documentation](https://github.com/fluxcd/flux/blob/master/docs/references/fluxctl.md#controlling-image-timestamps-with-labels), labeling images with `org.opencontainers.image.created=<iso timestamp>` suffices.
