### PR TITLE
chore: add go stats reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ vendor/
 *.swo
 .*swp
 
+.vscode
 .idea
 
 .tool-versions

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -56,6 +56,7 @@ stats:
     prefix: "push"
     buflen: 1
 pprof:
+  enabled: false
   host: "127.0.0.1"
   port: 8081
 invalidToken:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -55,6 +55,9 @@ stats:
     host: "localhost:8125"
     prefix: "push"
     buflen: 1
+pprof:
+  host: "127.0.0.1"
+  port: 8081
 invalidToken:
   pg:
     table: "test_apns"

--- a/config/docker_test.yaml
+++ b/config/docker_test.yaml
@@ -54,6 +54,9 @@ stats:
     host: "statsd:8125"
     prefix: "push"
     flushIntervalMs: 5000
+pprof:
+  host: "127.0.0.1"
+  port: 8081
 invalidToken:
   handlers:
     - pg

--- a/config/docker_test.yaml
+++ b/config/docker_test.yaml
@@ -55,6 +55,7 @@ stats:
     prefix: "push"
     flushIntervalMs: 5000
 pprof:
+  enabled: false
   host: "127.0.0.1"
   port: 8081
 invalidToken:

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -53,6 +53,7 @@ stats:
     prefix: "push"
     flushIntervalMs: 
 pprof:
+  enabled: false
   host: "127.0.0.1"
   port: 8081
 invalidToken:

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -51,7 +51,10 @@ stats:
   statsd:
     host: "localhost:40001"
     prefix: "push"
-    flushIntervalMs: 5000
+    flushIntervalMs: 
+pprof:
+  host: "127.0.0.1"
+  port: 8081
 invalidToken:
   handlers:
     - pg

--- a/feedback/listener.go
+++ b/feedback/listener.go
@@ -79,6 +79,7 @@ func (l *Listener) loadConfigurationDefaults() {
 	l.Config.SetDefault("feedbackListeners.gracefulShutdownTimeout", 1)
 	l.Config.SetDefault("stats.flush.s", 5)
 
+	l.Config.SetDefault("pprof.enabled", false)
 	l.Config.SetDefault("pprof.host", "127.0.0.1")
 	l.Config.SetDefault("pprof.port", 8081)
 }
@@ -134,7 +135,9 @@ func (l *Listener) Start() {
 	)
 	log.Info("starting the feedback listener...")
 
-	go l.StartPprofServer()
+	if l.Config.GetBool("pprof.enabled") {
+		go l.StartPprofServer()
+	}
 
 	go l.Queue.ConsumeLoop(context.Background())
 	l.Broker.Start()

--- a/feedback/listener.go
+++ b/feedback/listener.go
@@ -78,6 +78,9 @@ func NewListener(
 func (l *Listener) loadConfigurationDefaults() {
 	l.Config.SetDefault("feedbackListeners.gracefulShutdownTimeout", 1)
 	l.Config.SetDefault("stats.flush.s", 5)
+
+	l.Config.SetDefault("pprof.host", "127.0.0.1")
+	l.Config.SetDefault("pprof.port", 8081)
 }
 
 func (l *Listener) configure(statsdClientrOrNil interfaces.StatsDClient) error {
@@ -251,8 +254,9 @@ func (l *Listener) StartPprofServer() error {
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
+	addr := fmt.Sprintf("%s:%d", l.Config.GetString("pprof.host"), l.Config.GetInt("pprof.port"))
 	server := &http.Server{
-		Addr:    "127.0.0.1:8081",
+		Addr:    addr,
 		Handler: mux,
 	}
 

--- a/feedback/listener.go
+++ b/feedback/listener.go
@@ -138,7 +138,7 @@ func (l *Listener) Start() {
 	statsReporterReportMetricCount(l.StatsReporters,
 		"feedback_listener_restart", 1, "", "")
 
-	sigchan := make(chan os.Signal)
+	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	flushTicker := time.NewTicker(l.statsFlushTime)

--- a/pusher/pusher.go
+++ b/pusher/pusher.go
@@ -118,7 +118,7 @@ func (p *Pusher) Start(ctx context.Context) {
 	go p.Queue.ConsumeLoop(ctx)
 	go p.reportGoStats()
 
-	sigchan := make(chan os.Signal)
+	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	select {


### PR DESCRIPTION
Add Go runtime metrics to the Listener worker and start a pprof HTTP server bound to the loopback interface for debugging.