### PR TITLE
fix: change Kafka poll to block for 100ms instead of 100ns when no events

### DIFF
--- a/feedback/kafka_consumer.go
+++ b/feedback/kafka_consumer.go
@@ -25,6 +25,7 @@ package feedback
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/getsentry/raven-go"
@@ -211,7 +212,7 @@ func (q *KafkaConsumer) ConsumeLoop(ctx context.Context) error {
 			l.Info("context done, stopping consuming")
 			return nil
 		default:
-			message, err := q.Consumer.ReadMessage(100)
+			message, err := q.Consumer.ReadMessage(100 * time.Millisecond)
 			if message == nil && err.(kafka.Error).IsTimeout() {
 				continue
 			}


### PR DESCRIPTION
This change updates the Kafka consumer's polling behavior. Previously, the poll function blocked for 100 nanoseconds when no events were available, which caused unnecessary CPU usage due to frequent polling.

The polling now blocks for 100 milliseconds instead. This reduces CPU usage by allowing the consumer thread to sleep between checks for new events, rather than constantly polling. While this introduces a small increase in latency, the change results in more efficient resource utilization and avoids wasting CPU cycles when there are no events to process.