### PR TITLE
add debug logs to check why dedup is not working in staging

### DIFF
--- a/extensions/apns/apns_message_handler.go
+++ b/extensions/apns/apns_message_handler.go
@@ -194,7 +194,7 @@ func (a *APNSMessageHandler) HandleMessages(ctx context.Context, message interfa
 
 	uniqueMessage := a.dedup.IsUnique(ctx, parsedNotification.DeviceToken, string(message.Value), a.appName, "apns")
 	if !uniqueMessage {
-		l.WithField("message", message).Info("duplicate message detected")
+		l.WithField("message", message).Debug("duplicate message detected")
 		extensions.StatsReporterDuplicateMessageDetected(a.StatsReporters, a.appName, "apns")
 		//does not return because we don't want to block the message
 	}

--- a/extensions/common.go
+++ b/extensions/common.go
@@ -101,15 +101,14 @@ func StatsReporterReportSendNotificationLatency(statsReporters []interfaces.Stat
 	}
 }
 
-func StatsReporterDuplicateMessageDetected(reporters []interfaces.StatsReporter, game string, platform string) {
-	for _, reporter := range reporters {
-		reporter.ReportMetricCount("duplicated_messages", 1, game, platform)
+func StatsReporterDuplicateMessageDetected(statsReporters []interfaces.StatsReporter, game string, platform string) {
+	for _, statsReporter := range statsReporters {
+		statsReporter.ReportMetricCount("duplicated_messages", 1, game, platform)
 	}
 }
 
-func StatsReporterDedupFailed(reporters []interfaces.StatsReporter, game string, platform string) {
-	for _, reporter := range reporters {
-		reporter.ReportMetricCount("dedup_errors", 1, game, platform)
-		// Or use HandleNotificationFailure if you want to reuse existing metrics
+func StatsReporterDedupFailed(statsReporters []interfaces.StatsReporter, game string, platform string) {
+	for _, statsReporter := range statsReporters {
+		statsReporter.ReportMetricCount("dedup_errors", 1, game, platform)
 	}
 }

--- a/extensions/dedup_messages.go
+++ b/extensions/dedup_messages.go
@@ -66,17 +66,24 @@ func NewDedup(ttl time.Duration, config *viper.Viper, statsReporters []interface
 }
 
 func (d dedup) IsUnique(ctx context.Context, device, msg, game, platform string) bool {
-	d.l.Debug("Checking message deduplication")
 	// Get percentage for dedup sampling for specific game
 	percentage := d.gamePercentages[game]
 
+	log := d.l.WithFields(logrus.Fields{
+		"percentage": percentage,
+		"device":    device,
+		"msg":      msg,
+	})
+
+	log.Debug("Checking message deduplication")
+
 	if percentage == 0 {
-		d.l.Debug("Deduplication sampling percentage is 0, skipping deduplication check")
+		log.Debug("Deduplication sampling percentage is 0, skipping deduplication check")
 		return true
 	}
 
 	if percentage > 0 && percentage < 100 {
-		d.l.Debug("Deduplication sampling percentage is above 0 and below 100, checking if should sample")
+		log.Debug("Deduplication sampling percentage is above 0 and below 100, checking if should sample")
 		h := fnv.New64a()
 		h.Write([]byte(device))
 
@@ -84,28 +91,27 @@ func (d dedup) IsUnique(ctx context.Context, device, msg, game, platform string)
 		// Use the top 16 bits of the hash to determine if we should sample
 		sampleValue := int(sum >> 48)
 		samplePercentile := sampleValue % 100
-		d.l.WithFields(logrus.Fields{
+		log.WithFields(logrus.Fields{
 			"sampleValue":      sampleValue,
 			"samplePercentile": samplePercentile,
 			"percentage":       percentage,
 		}).Debug("Deduplication sampling value and percentile")
 		if samplePercentile >= percentage {
-			d.l.Debug("Deduplication sampling percentage check didn't pass, skipping deduplication check")
+			log.Debug("Deduplication sampling percentage check didn't pass, skipping deduplication check")
 			return true
 		}
 	}
 
-	d.l.Debug("Deduplication sampling percentage check passed, proceeding with deduplication check")
+	log.Debug("Deduplication sampling percentage check passed, proceeding with deduplication check")
 	rdbKey := keyFor(device, msg)
 
 	// Store the key in Redis with a placeholder value ("1")—the actual value is irrelevant, as we only need to check for key existence.
 	unique, err := d.redis.SetNX(ctx, rdbKey, "1", d.ttl).Result()
 
 	if err != nil {
-		d.l.WithFields(logrus.Fields{
+		log.WithFields(logrus.Fields{
 			"error":  err,
 			"key":    rdbKey,
-			"device": device,
 			"game":   game,
 		}).Error("Failed to check message dedup in Redis")
 

--- a/extensions/dedup_messages.go
+++ b/extensions/dedup_messages.go
@@ -84,7 +84,11 @@ func (d dedup) IsUnique(ctx context.Context, device, msg, game, platform string)
 		// Use the top 16 bits of the hash to determine if we should sample
 		sampleValue := int(sum >> 48)
 		samplePercentile := sampleValue % 100
-
+		d.l.WithFields(logrus.Fields{
+			"sampleValue":      sampleValue,
+			"samplePercentile": samplePercentile,
+			"percentage":       percentage,
+		}).Debug("Deduplication sampling value and percentile")
 		if samplePercentile >= percentage {
 			d.l.Debug("Deduplication sampling percentage check didn't pass, skipping deduplication check")
 			return true

--- a/extensions/firebase/message_handler.go
+++ b/extensions/firebase/message_handler.go
@@ -100,7 +100,7 @@ func (h *messageHandler) HandleMessages(ctx context.Context, msg interfaces.Kafk
 
 	uniqueMessage := h.dedup.IsUnique(ctx, km.To, string(msg.Value), h.app, "gcm")
 	if !uniqueMessage {
-		l.WithField("message", msg).Info("duplicate message detected")
+		l.WithField("message", msg).Debug("duplicate message detected")
 		extensions.StatsReporterDuplicateMessageDetected(h.statsReporters, h.app, "gcm")
 		//does not return because we don't want to block the message
 	}


### PR DESCRIPTION
This pull request introduces changes to improve logging granularity and consistency in the deduplication logic and related components. The changes include adjustments to log levels, additional debug logs for deduplication checks, and minor refactoring for better readability in metrics reporting functions.

### Logging Improvements:
* Changed log level from `Info` to `Debug` for duplicate message detection in `APNSMessageHandler` (`apns_message_handler.go`) and Firebase `messageHandler` (`message_handler.go`) to reduce noise in production logs. [[1]](diffhunk://#diff-aea4632f9c3fe6eeec0418088a4c524c3a2883a7c03fcb0b3cb53a95e03578c2L197-R197) [[2]](diffhunk://#diff-ae20546712c58b36e20d46d4de8578ad6bcca5eaa27fdfb38d033b802184254dL103-R103)
* Added detailed debug logs in the `IsUnique` method of the deduplication logic to trace deduplication sampling and decision-making processes (`dedup_messages.go`). [[1]](diffhunk://#diff-9dedb9c7e605c9f60311978edd5dc53428e0898a66913f577e1503030343e276L69-R79) [[2]](diffhunk://#diff-9dedb9c7e605c9f60311978edd5dc53428e0898a66913f577e1503030343e276R89-R94)

### Code Refactoring:
* Renamed variables in metrics reporting functions (`StatsReporterDuplicateMessageDetected` and `StatsReporterDedupFailed`) for consistency and clarity (`common.go`).