### PR TITLE
Feat/dedup notifications

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -2,6 +2,7 @@
 gracefulShutdownTimeout: 30
 apns:
   rateLimit.rpm: 20
+  dedup.ttl: "60s"
   concurrentWorkers: 300
   connectionPoolSize: 1
   pushQueueSize: 100
@@ -17,6 +18,7 @@ apns:
 gcm:
   rateLimit.rpm: 20
   pingInterval: 30
+  dedup.ttl: "60s"
   pingTimeout: 10
   maxPendingMessages: 100
   logStatsInterval: 10000

--- a/e2e/fcm_e2e_test.go
+++ b/e2e/fcm_e2e_test.go
@@ -108,7 +108,7 @@ func (s *FcmE2ETestSuite) TestSimpleNotification() {
 	s.Require().NoError(err)
 
 	topic := fmt.Sprintf(gcmTopicTemplate, appName)
-	token := "token"
+	token := "token-simple"
 	testDone := make(chan bool)
 	mockFcmClient.EXPECT().
 		SendPush(gomock.Any(), gomock.Any()).
@@ -140,7 +140,7 @@ func (s *FcmE2ETestSuite) TestSimpleNotification() {
 			Topic:     &topic,
 			Partition: kafka.PartitionAny,
 		},
-		Value: []byte(`{"deviceToken":"` + token + `", "payload": {"gcm": {"alert": "Hello"}}}`),
+		Value: []byte(`{"to":"` + token + `", "data": {"alert": "Hello Simple"}}`),
 	},
 		nil)
 	s.Require().NoError(err)
@@ -170,7 +170,7 @@ func (s *FcmE2ETestSuite) TestMultipleNotifications() {
 	s.Require().NoError(err)
 
 	topic := fmt.Sprintf(gcmTopicTemplate, appName)
-	token := "token"
+	token := "token-multiple"
 	done := make(chan bool)
 
 	for i := 0; i < notificationsToSend; i++ {
@@ -210,7 +210,7 @@ func (s *FcmE2ETestSuite) TestMultipleNotifications() {
 				Topic:     &topic,
 				Partition: kafka.PartitionAny,
 			},
-			Value: []byte(`{"deviceToken":"` + fmt.Sprintf("%s%d", token, i) + `", "payload": {"gcm": {"alert": "Hello"}}}`),
+			Value: []byte(`{"to":"` + fmt.Sprintf("%s%d", token, i) + `", "data": {"alert": "Hello Multiple"}}`),
 		},
 			nil)
 		s.Require().NoError(err)
@@ -294,7 +294,7 @@ func (s *FcmE2ETestSuite) TestDuplicatedMessages() {
 				Topic:     &topic,
 				Partition: kafka.PartitionAny,
 			},
-			Value: []byte(`{"deviceToken":"` + token + `", "payload": {"gcm": {"alert": "Hello"}}}`),
+			Value: []byte(`{"to":"` + token + `", "data": {"alert": "Hello Duplicated"}}`),
 		},
 			nil)
 		s.Require().NoError(err)

--- a/extensions/apns/apns_message_handler.go
+++ b/extensions/apns/apns_message_handler.go
@@ -197,7 +197,7 @@ func (a *APNSMessageHandler) HandleMessages(ctx context.Context, message interfa
 	if !uniqueMessage {
 		l.WithFields(log.Fields{
 			"extension": "dedup",
-			"game":     a.appName,
+			"game":      a.appName,
 		}).Debug("duplicate message detected")
 		extensions.StatsReporterDuplicateMessageDetected(a.StatsReporters, a.appName, "apns")
 		//does not return because we don't want to block the message

--- a/extensions/apns/apns_message_handler.go
+++ b/extensions/apns/apns_message_handler.go
@@ -194,9 +194,7 @@ func (a *APNSMessageHandler) HandleMessages(ctx context.Context, message interfa
 
 	// if there is any error on deduplication, it does not block the message.
 	dedupMsg, err := a.createDedupContentFromPayload(parsedNotification)
-	if err != nil {
-		l.WithError(err).Error("error creating deduplication content from payload")
-	} else {
+	if err == nil {
 		uniqueMessage := a.dedup.IsUnique(ctx, parsedNotification.DeviceToken, dedupMsg, a.appName, "apns")
 		if !uniqueMessage {
 			l.WithFields(log.Fields{
@@ -206,6 +204,8 @@ func (a *APNSMessageHandler) HandleMessages(ctx context.Context, message interfa
 			extensions.StatsReporterDuplicateMessageDetected(a.StatsReporters, a.appName, "apns")
 			//does not return because we don't want to block the message
 		}
+	} else {
+		l.WithError(err).Error("error creating deduplication content from payload")
 	}
 
 

--- a/extensions/dedup_messages.go
+++ b/extensions/dedup_messages.go
@@ -63,13 +63,6 @@ func NewDedup(ttl time.Duration, config *viper.Viper, statsReporters []interface
 		}).Error("Failed to unmarshal dedup games config")
 	}
 
-	for gameName, percentage := range gamePercentages {
-		log.WithFields(logrus.Fields{
-            "gameName": gameName,
-            "percentage": percentage,
-        }).Debug("Dedup game config loaded")
-	}
-
 	rdb := redis.NewClient(opts)
 
 	return dedup{
@@ -123,13 +116,13 @@ func (d dedup) IsUnique(ctx context.Context, device, msg, game, platform string)
 	rdbKey := keyFor(device, msg)
 
 	rArgs := &redis.SetArgs{
-		Mode: "NX",
-		TTL: d.ttl,
+		Mode: `NX`, 
+		TTL:  d.ttl,
 	}
 
 	// Store the key in Redis with a placeholder value ("1")—the actual value is irrelevant, as we only need to check for key existence.
 	unique, err := d.redis.SetArgs(ctx, rdbKey, "1", *rArgs).Result();
-
+	
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			log.WithField("key", rdbKey).Debug("Message is not unique, key already exists in Redis")

--- a/extensions/dedup_messages.go
+++ b/extensions/dedup_messages.go
@@ -127,10 +127,7 @@ func (d dedup) IsUnique(ctx context.Context, device, msg, game, platform string)
 			return false
 
 		} else {
-			log.WithFields(logrus.Fields{
-				"error": err,
-				"key":   rdbKey,
-			}).Error("Failed to check uniqueness in Redis")
+			log.WithError(err).Error("Failed to check uniqueness in Redis")
 			return true // Allow the operation to proceed even if Redis check fails, to avoid blocking notifications.
 		}
 	}

--- a/extensions/dedup_messages.go
+++ b/extensions/dedup_messages.go
@@ -16,6 +16,7 @@ import (
 	"github.com/topfreegames/pusher/interfaces"
 )
 
+var dedupRedisDB = 1
 // Dedup struct
 type dedup struct {
 	redis             *redis.Client
@@ -42,6 +43,7 @@ func NewDedup(ttl time.Duration, config *viper.Viper, statsReporters []interface
 	opts := &redis.Options{
 		Addr:     addr,
 		Password: pwd,
+		DB:       dedupRedisDB,
 	}
 
 	if !disableTLS {

--- a/extensions/dedup_messages.go
+++ b/extensions/dedup_messages.go
@@ -16,7 +16,7 @@ import (
 	"github.com/topfreegames/pusher/interfaces"
 )
 
-var dedupRedisDB = 1
+const dedupRedisDB = 1
 // Dedup struct
 type dedup struct {
 	redis             *redis.Client

--- a/extensions/dedup_messages.go
+++ b/extensions/dedup_messages.go
@@ -15,8 +15,6 @@ import (
 	"github.com/topfreegames/pusher/interfaces"
 )
 
-// a different redis DB for dedup keeps dedup keys separate from Rate Limiter keys stored in default DB = 0
-const DedupRedisDB = 1
 // Dedup struct
 type dedup struct {
 	redis             *redis.Client
@@ -34,13 +32,15 @@ func NewDedup(ttl time.Duration, config *viper.Viper, statsReporters []interface
 
 	log := logger.WithFields(logrus.Fields{
 		"extension": "Dedup",
+		"host":      host,
+		"port":      port,
+		"disableTLS": disableTLS,
 	})
 
 	addr := fmt.Sprintf("%s:%d", host, port)
 	opts := &redis.Options{
 		Addr:     addr,
 		Password: pwd,
-		DB:       DedupRedisDB,
 	}
 
 	if !disableTLS {
@@ -68,15 +68,6 @@ func NewDedup(ttl time.Duration, config *viper.Viper, statsReporters []interface
             "percentage": percentage,
         }).Debug("Dedup game config loaded")
 	}
-
-	
-	// for game := range games {
-	// 	log.Debug("Dedup game key found in config: ", game)
-	// 	percentageConfigKey := "dedup.games." + game + ".percentage"
-
-	// 	config.SetDefault(percentageConfigKey, 0)
-	// 	gamePercentages[game] = config.GetInt(percentageConfigKey)
-	// }
 
 	rdb := redis.NewClient(opts)
 

--- a/extensions/dedup_messages.go
+++ b/extensions/dedup_messages.go
@@ -85,15 +85,12 @@ func (d dedup) IsUnique(ctx context.Context, device, msg, game, platform string)
 		"game":     game,
 	})
 
-	log.Debug("Checking message deduplication")
-
 	if percentage == 0 {
 		log.Debug("Deduplication sampling percentage is 0, skipping deduplication check")
 		return true
 	}
 
 	if percentage > 0 && percentage < 100 {
-		log.Debug("Deduplication sampling percentage is above 0 and below 100, checking if should sample")
 		h := fnv.New64a()
 		h.Write([]byte(device))
 
@@ -112,7 +109,6 @@ func (d dedup) IsUnique(ctx context.Context, device, msg, game, platform string)
 		}
 	}
 
-	log.Debug("Deduplication sampling percentage check passed, proceeding with deduplication check")
 	rdbKey := keyFor(device, msg)
 
 	rArgs := &redis.SetArgs{

--- a/extensions/dedup_messages_test.go
+++ b/extensions/dedup_messages_test.go
@@ -159,13 +159,13 @@ func TestIsUnique(t *testing.T) {
 			message := "test-message"
 
 			// Get keys count before
-			keyCountBefore := len(mr.DB(1).Keys())
+			keyCountBefore := len(mr.DB(0).Keys())
 
 			// Call IsUnique
 			d.IsUnique(context.Background(), device, message, appName, "platform")
 
 			// Check if Redis was actually called (key was created)
-			keyCountAfter := len(mr.DB(1).Keys())
+			keyCountAfter := len(mr.DB(0).Keys())
 			if keyCountAfter > keyCountBefore {
 				sampledCount++
 			}

--- a/extensions/dedup_messages_test.go
+++ b/extensions/dedup_messages_test.go
@@ -159,13 +159,13 @@ func TestIsUnique(t *testing.T) {
 			message := "test-message"
 
 			// Get keys count before
-			keyCountBefore := len(mr.DB(0).Keys())
+			keyCountBefore := len(mr.DB(1).Keys())
 
 			// Call IsUnique
 			d.IsUnique(context.Background(), device, message, appName, "platform")
 
 			// Check if Redis was actually called (key was created)
-			keyCountAfter := len(mr.DB(0).Keys())
+			keyCountAfter := len(mr.DB(1).Keys())
 			if keyCountAfter > keyCountBefore {
 				sampledCount++
 			}

--- a/extensions/firebase/message_handler.go
+++ b/extensions/firebase/message_handler.go
@@ -103,7 +103,7 @@ func (h *messageHandler) HandleMessages(ctx context.Context, msg interfaces.Kafk
 	if !uniqueMessage {
 		l.WithFields(logrus.Fields{
 			"extension": "dedup",
-			"game":     h.app,
+			"game":      h.app,
 		}).Debug("duplicate message detected")
 		extensions.StatsReporterDuplicateMessageDetected(h.statsReporters, h.app, "gcm")
 		//does not return because we don't want to block the message

--- a/extensions/firebase/message_handler_test.go
+++ b/extensions/firebase/message_handler_test.go
@@ -461,7 +461,7 @@ func (s *MessageHandlerTestSuite) TestHandleResponse() {
 		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
 		dedupMsg := createDedupContentForTest(msgValue)
 		s.Require().NoError(err)
-		
+
 		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
@@ -528,16 +528,16 @@ func waitWG(t *testing.T, wg *sync.WaitGroup) {
 }
 
 func createDedupContentForTest(km kafkaFCMMessage) string {
-    contentData := make(map[string]interface{})
-    
-    if km.Data != nil {
-        contentData["data"] = km.Data
-    }
-    
-    if km.Message.Notification != nil {
-        contentData["notification"] = km.Message.Notification
-    }
-    
-    contentJSON, _ := json.Marshal(contentData)
-    return string(contentJSON)
+	contentData := make(map[string]interface{})
+
+	if km.Data != nil {
+		contentData["data"] = km.Data
+	}
+
+	if km.Message.Notification != nil {
+		contentData["notification"] = km.Message.Notification
+	}
+
+	contentJSON, _ := json.Marshal(contentData)
+	return string(contentJSON)
 }

--- a/extensions/firebase/message_handler_test.go
+++ b/extensions/firebase/message_handler_test.go
@@ -3,7 +3,6 @@ package firebase
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -117,19 +116,28 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 	})
 
 	s.Run("should fail if rate limit reached", func() {
-		expiration := time.Now().Add(1 * time.Hour).UnixNano()
 		token := uuid.NewString()
-		msg := interfaces.KafkaMessage{
-			Topic: "push-game_gcm",
-			Game:  s.game,
-			Value: []byte(fmt.Sprintf(`{"To": "%s", "Payload": { "aps" : { "alert" : "Hello HTTP/2" } }, "Metadata": { "expiration": 0 }, "push_expiry": %d }`,
-				token,
-				expiration,
-			)),
+		msgValue := kafkaFCMMessage{
+			Message: interfaces.Message{
+				To: token,
+				Data: map[string]interface{}{
+					"title": "notification",
+					"body":  "body",
+				},
+			},
+			Metadata: map[string]interface{}{
+				"some": "metadata",
+			},
 		}
+		bytes, err := json.Marshal(msgValue)
+		s.Require().NoError(err)
+
+		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
+		dedupMsg := createDedupContentForTest(msgValue)
+		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
-			IsUnique(gomock.Any(), token, string(msg.Value), s.game, "gcm").
+			IsUnique(gomock.Any(), token, dedupMsg, s.game, "gcm").
 			Return(true)
 
 		s.mockRateLimiter.EXPECT().
@@ -160,11 +168,14 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 			},
 		}
 		bytes, err := json.Marshal(msgValue)
+		s.Require().NoError(err)
+
 		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
+		dedupMsg := createDedupContentForTest(msgValue)
 		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
-			IsUnique(gomock.Any(), token, string(msg.Value), s.game, "gcm").
+			IsUnique(gomock.Any(), token, dedupMsg, s.game, "gcm").
 			Return(false)
 
 		s.mockStatsReporter.EXPECT().
@@ -218,11 +229,14 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 			},
 		}
 		bytes, err := json.Marshal(msgValue)
+		s.Require().NoError(err)
 		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
+
+		dedupMsg := createDedupContentForTest(msgValue)
 		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
-			IsUnique(gomock.Any(), token, string(msg.Value), s.game, "gcm").
+			IsUnique(gomock.Any(), token, dedupMsg, s.game, "gcm").
 			Return(true)
 
 		s.mockRateLimiter.EXPECT().
@@ -289,6 +303,7 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 			}
 			return km
 		}
+
 		go s.handler.HandleResponses()
 		qtyMsgs := 100
 
@@ -370,11 +385,13 @@ func (s *MessageHandlerTestSuite) TestHandleResponse() {
 			},
 		}
 		bytes, err := json.Marshal(msgValue)
+		s.Require().NoError(err)
 		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
+		dedupMsg := createDedupContentForTest(msgValue)
 		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
-			IsUnique(gomock.Any(), token, string(msg.Value), s.game, "gcm").
+			IsUnique(gomock.Any(), token, dedupMsg, s.game, "gcm").
 			Return(true)
 
 		s.mockRateLimiter.EXPECT().
@@ -439,11 +456,16 @@ func (s *MessageHandlerTestSuite) TestHandleResponse() {
 			},
 		}
 		bytes, err := json.Marshal(msgValue)
+		s.Require().NoError(err)
+
 		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
+		dedupMsg := createDedupContentForTest(msgValue)
+		s.Require().NoError(err)
+		
 		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
-			IsUnique(gomock.Any(), token, string(msg.Value), s.game, "gcm").
+			IsUnique(gomock.Any(), token, dedupMsg, s.game, "gcm").
 			Return(true)
 
 		s.mockRateLimiter.EXPECT().
@@ -503,4 +525,19 @@ func waitWG(t *testing.T, wg *sync.WaitGroup) {
 	case <-timeout:
 		t.Fatal("timed out waiting for waitgroup")
 	}
+}
+
+func createDedupContentForTest(km kafkaFCMMessage) string {
+    contentData := make(map[string]interface{})
+    
+    if km.Data != nil {
+        contentData["data"] = km.Data
+    }
+    
+    if km.Message.Notification != nil {
+        contentData["notification"] = km.Message.Notification
+    }
+    
+    contentJSON, _ := json.Marshal(contentData)
+    return string(contentJSON)
 }

--- a/extensions/firebase/message_handler_test.go
+++ b/extensions/firebase/message_handler_test.go
@@ -133,7 +133,7 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 		s.Require().NoError(err)
 
 		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
-		dedupMsg := createDedupContentForTest(msgValue)
+		dedupMsg, err := createDedupContentForTest(msgValue)
 		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
@@ -171,7 +171,7 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 		s.Require().NoError(err)
 
 		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
-		dedupMsg := createDedupContentForTest(msgValue)
+		dedupMsg, err := createDedupContentForTest(msgValue)
 		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
@@ -232,7 +232,7 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 		s.Require().NoError(err)
 		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
 
-		dedupMsg := createDedupContentForTest(msgValue)
+		dedupMsg, err := createDedupContentForTest(msgValue)
 		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
@@ -387,7 +387,7 @@ func (s *MessageHandlerTestSuite) TestHandleResponse() {
 		bytes, err := json.Marshal(msgValue)
 		s.Require().NoError(err)
 		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
-		dedupMsg := createDedupContentForTest(msgValue)
+		dedupMsg, err := createDedupContentForTest(msgValue)
 		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
@@ -459,9 +459,7 @@ func (s *MessageHandlerTestSuite) TestHandleResponse() {
 		s.Require().NoError(err)
 
 		msg := interfaces.KafkaMessage{Value: bytes, Topic: "push-game_gcm", Game: s.game}
-		dedupMsg := createDedupContentForTest(msgValue)
-		s.Require().NoError(err)
-
+		dedupMsg, err := createDedupContentForTest(msgValue)
 		s.Require().NoError(err)
 
 		s.mockDedup.EXPECT().
@@ -527,7 +525,7 @@ func waitWG(t *testing.T, wg *sync.WaitGroup) {
 	}
 }
 
-func createDedupContentForTest(km kafkaFCMMessage) string {
+func createDedupContentForTest(km kafkaFCMMessage) (string, error) {
 	contentData := make(map[string]interface{})
 
 	if km.Data != nil {
@@ -538,6 +536,9 @@ func createDedupContentForTest(km kafkaFCMMessage) string {
 		contentData["notification"] = km.Message.Notification
 	}
 
-	contentJSON, _ := json.Marshal(contentData)
-	return string(contentJSON)
+	contentJSON, err := json.Marshal(contentData)
+	if err != nil {
+		return "", err
+	}
+	return string(contentJSON), nil
 }


### PR DESCRIPTION
The key changes include the addition of methods for creating deduplication content from payloads, updates to Redis interaction for deduplication checks, and enhancements to test coverage.

### Deduplication Logic Enhancements:
* **APNS Message Handling**: Added a method `createDedupContentFromPayload` to extract relevant deduplication content from the notification payload, focusing on the `aps` section. Updated the `HandleMessages` function to use this deduplication content instead of the raw message value. (`extensions/apns/apns_message_handler.go`, [[1]](diffhunk://#diff-aea4632f9c3fe6eeec0418088a4c524c3a2883a7c03fcb0b3cb53a95e03578c2L195-R196) [[2]](diffhunk://#diff-aea4632f9c3fe6eeec0418088a4c524c3a2883a7c03fcb0b3cb53a95e03578c2R249-R271)
* **Firebase Message Handling**: Added a method `createDedupContentFromPayload` to extract deduplication content from `Data` and `Notification` fields of the `kafkaFCMMessage`. Updated the `HandleMessages` function to use this deduplication content. (`extensions/firebase/message_handler.go`, [[1]](diffhunk://#diff-ae20546712c58b36e20d46d4de8578ad6bcca5eaa27fdfb38d033b802184254dL101-R102) [[2]](diffhunk://#diff-ae20546712c58b36e20d46d4de8578ad6bcca5eaa27fdfb38d033b802184254dR136-R154)

### Redis Deduplication Updates:
* **Redis Set Arguments**: Replaced `SetNX` with `SetArgs` to provide more control over Redis operations, including specifying `NX` mode and TTL. Added error handling to ensure non-blocking behavior in case of Redis failures. (`extensions/dedup_messages.go`, [[1]](diffhunk://#diff-9dedb9c7e605c9f60311978edd5dc53428e0898a66913f577e1503030343e276L103-L111) [[2]](diffhunk://#diff-9dedb9c7e605c9f60311978edd5dc53428e0898a66913f577e1503030343e276L130-R141)
* **Redis DB Adjustment**: Removed the use of a separate Redis DB for deduplication, consolidating keys into the default DB. Updated test cases to reflect this change. (`extensions/dedup_messages.go`, [[1]](diffhunk://#diff-9dedb9c7e605c9f60311978edd5dc53428e0898a66913f577e1503030343e276L18-L19); `extensions/dedup_messages_test.go`, [[2]](diffhunk://#diff-0d04db8ae2dac4b50de2b327ed1b0aba8d082360bf57de0600e8832da2763cd4L162-R168)

### Test Case Refactoring:
* **Firebase Tests**: Refactored test cases to use the new deduplication content creation logic, ensuring alignment with the updated `IsUnique` method. Added helper function `createDedupContentForTest` for generating deduplication content in tests. (`extensions/firebase/message_handler_test.go`, [[1]](diffhunk://#diff-b03d48e5ca50c81bcc00400ab42f9fc1c83c17312c5c86f5c3229bee24ef7b28L120-R140) [[2]](diffhunk://#diff-b03d48e5ca50c81bcc00400ab42f9fc1c83c17312c5c86f5c3229bee24ef7b28R171-R178) [[3]](diffhunk://#diff-b03d48e5ca50c81bcc00400ab42f9fc1c83c17312c5c86f5c3229bee24ef7b28R232-R239) [[4]](diffhunk://#diff-b03d48e5ca50c81bcc00400ab42f9fc1c83c17312c5c86f5c3229bee24ef7b28R388-R394) [[5]](diffhunk://#diff-b03d48e5ca50c81bcc00400ab42f9fc1c83c17312c5c86f5c3229bee24ef7b28R459-R468) [[6]](diffhunk://#diff-b03d48e5ca50c81bcc00400ab42f9fc1c83c17312c5c86f5c3229bee24ef7b28R529-R543)
* **APNS Tests**: Adjusted test cases to validate deduplication logic changes for APNS messages. (`extensions/dedup_messages_test.go`, [extensions/dedup_messages_test.goL162-R168](diffhunk://#diff-0d04db8ae2dac4b50de2b327ed1b0aba8d082360bf57de0600e8832da2763cd4L162-R168))

These changes collectively improve the robustness and maintainability of the deduplication logic while ensuring compatibility with existing functionality.