### PR TITLE
add configurable log level and fix unit tests

### DIFF
--- a/cmd/apns.go
+++ b/cmd/apns.go
@@ -24,6 +24,7 @@ package cmd
 
 import (
 	"context"
+
 	raven "github.com/getsentry/raven-go"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -49,7 +50,9 @@ func startApns(
 	if debug {
 		log.Level = logrus.DebugLevel
 	} else {
-		log.Level = logrus.InfoLevel
+		// Check config for log level, fall back to info level
+		configLogLevel := vConfig.GetString("log.level")
+		log.Level = util.ParseLogLevel(configLogLevel)
 	}
 	return pusher.NewAPNSPusher(production, vConfig, config, log, statsdClientOrNil, dbOrNil, queueOrNil)
 }

--- a/cmd/feedback_listener.go
+++ b/cmd/feedback_listener.go
@@ -42,13 +42,14 @@ func newFeedbackListener(
 	if debug {
 		log.Level = logrus.DebugLevel
 	} else {
-		log.Level = logrus.InfoLevel
+		configLogLevel := config.GetString("log.level")
+		log.Level = util.ParseLogLevel(configLogLevel)
 	}
 
 	return feedback.NewListener(config, log, nil)
 }
 
-// starFeedbackListenerCmd represents the start-feedback-listener command
+// startFeedbackListenerCmd represents the start-feedback-listener command
 var startFeedbackListenerCmd = &cobra.Command{
 	Use:   "start-feedback-listener",
 	Short: "starts the feedback listener",

--- a/cmd/gcm.go
+++ b/cmd/gcm.go
@@ -24,12 +24,14 @@ package cmd
 
 import (
 	"context"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/pusher/config"
 	"github.com/topfreegames/pusher/interfaces"
 	"github.com/topfreegames/pusher/pusher"
+	"github.com/topfreegames/pusher/util"
 )
 
 var senderID string
@@ -49,7 +51,8 @@ func startGcm(
 	if debug {
 		log.Level = logrus.DebugLevel
 	} else {
-		log.Level = logrus.InfoLevel
+		configLogLevel := vConfig.GetString("log.level")
+		log.Level = util.ParseLogLevel(configLogLevel)
 	}
 	return pusher.NewGCMPusher(ctx, production, vConfig, config, log, statsdClientOrNil)
 }

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,5 +1,7 @@
 ---
 gracefulShutdownTimeout: 30
+log:
+  level: "info"  # Can be: debug, info, warn, error
 apns:
   rateLimit.rpm: 20
   dedup.ttl: "60s"

--- a/extensions/firebase/message_handler_test.go
+++ b/extensions/firebase/message_handler_test.go
@@ -122,7 +122,7 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 				To: token,
 				Data: map[string]interface{}{
 					"title": "notification",
-					"body":  "body",
+					"body":  "bodyRateLimit",
 				},
 			},
 			Metadata: map[string]interface{}{
@@ -160,7 +160,7 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 				To: token,
 				Data: map[string]interface{}{
 					"title": "notification",
-					"body":  "body",
+					"body":  "bodyDedup",
 				},
 			},
 			Metadata: map[string]interface{}{
@@ -221,7 +221,7 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 				To: token,
 				Data: map[string]interface{}{
 					"title": "notification",
-					"body":  "body",
+					"body":  "bodySuccess",
 				},
 			},
 			Metadata: map[string]interface{}{
@@ -377,7 +377,7 @@ func (s *MessageHandlerTestSuite) TestHandleResponse() {
 				To: token,
 				Data: map[string]interface{}{
 					"title": "notification",
-					"body":  "body",
+					"body":  "bodySendMetricOnFailure",
 				},
 			},
 			Metadata: map[string]interface{}{
@@ -448,7 +448,7 @@ func (s *MessageHandlerTestSuite) TestHandleResponse() {
 				To: token,
 				Data: map[string]interface{}{
 					"title": "notification",
-					"body":  "body",
+					"body":  "bodyAckMetricOnSuccess",
 				},
 			},
 			Metadata: map[string]interface{}{

--- a/util/config.go
+++ b/util/config.go
@@ -25,8 +25,30 @@ package util
 import (
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
+
+// ParseLogLevel converts a log level string to logrus.Level
+// Returns logrus.InfoLevel as default if level is invalid
+func ParseLogLevel(level string) logrus.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return logrus.DebugLevel
+	case "info":
+		return logrus.InfoLevel
+	case "warn", "warning":
+		return logrus.WarnLevel
+	case "error":
+		return logrus.ErrorLevel
+	case "fatal":
+		return logrus.FatalLevel
+	case "panic":
+		return logrus.PanicLevel
+	default:
+		return logrus.InfoLevel
+	}
+}
 
 // NewViperWithConfigFile for getting a viper with default configs for the project.
 func NewViperWithConfigFile(configFile string) (*viper.Viper, error) {


### PR DESCRIPTION
allow configurable log level

also fixed unit tests: one same simulated redis was being used by multiple runs that had the same notification body, which was being catched by dedup. Made each notification unique for each test and worked. Weird behavior, guess message handler tests are still flaky because this issue passed unnoticed by CI tests on last commit