### PR TITLE
feat(firebase): thread platform through message handler

### DIFF
--- a/extensions/firebase/message_handler.go
+++ b/extensions/firebase/message_handler.go
@@ -92,6 +92,12 @@ func (h *messageHandler) HandleMessages(ctx context.Context, msg interfaces.Kafk
 		return
 	}
 
+	platform := msg.Platform
+	if platform == "" {
+		platform = "gcm"
+	}
+	km.Message.Platform = platform
+
 	if km.PushExpiry > 0 && km.PushExpiry < extensions.MakeTimestamp() {
 		l.Warnf("ignoring push message because it has expired: %s", km.Data)
 		h.waitGroupDone()
@@ -101,22 +107,22 @@ func (h *messageHandler) HandleMessages(ctx context.Context, msg interfaces.Kafk
 	// if there is any error on deduplication, it does not block the message.
 	dedupMsg, err := h.createDedupContentFromPayload(km)
 	if err == nil {
-		uniqueMessage := h.dedup.IsUnique(ctx, km.To, dedupMsg, h.app, "gcm")
+		uniqueMessage := h.dedup.IsUnique(ctx, km.To, dedupMsg, h.app, platform)
 		if !uniqueMessage {
 			l.WithFields(logrus.Fields{
 				"extension": "dedup",
 				"game":      h.app,
 			}).Debug("duplicate message detected")
-			extensions.StatsReporterDuplicateMessageDetected(h.statsReporters, h.app, "gcm")
+			extensions.StatsReporterDuplicateMessageDetected(h.statsReporters, h.app, platform)
 			//does not return because we don't want to block the message
 		}
 	} else {
 		l.WithError(err).Error("error creating deduplication content from payload")
 	}
 
-	allowed := h.rateLimiter.Allow(ctx, km.To, msg.Game, "gcm")
+	allowed := h.rateLimiter.Allow(ctx, km.To, msg.Game, platform)
 	if !allowed {
-		h.reportRateLimitReached(msg.Game)
+		h.reportRateLimitReached(msg.Game, platform)
 		h.waitGroupDone()
 		l.WithField("message", msg).Warn("rate limit reached")
 		return
@@ -134,7 +140,7 @@ func (h *messageHandler) HandleMessages(ctx context.Context, msg interfaces.Kafk
 		}
 	}
 	before := time.Now()
-	defer h.reportLatency(time.Since(before))
+	defer h.reportLatency(time.Since(before), platform)
 	h.sendPush(ctx, km.Message, msg.Topic)
 }
 
@@ -169,7 +175,7 @@ func (h *messageHandler) sendPush(ctx context.Context, msg interfaces.Message, t
 		err := h.client.SendPush(ctx, msg)
 		h.reportFirebaseLatency(time.Since(before))
 
-		h.handleNotificationSent(topic)
+		h.handleNotificationSent(topic, msg.Platform)
 
 		h.responsesChannel <- struct {
 			msg   interfaces.Message
@@ -189,9 +195,9 @@ func (h *messageHandler) HandleResponses() {
 			for {
 				response := <-h.responsesChannel
 				if response.error != nil {
-					h.handleNotificationFailure(response.msg, response.error)
+					h.handleNotificationFailure(response.msg, response.msg.Platform, response.error)
 				} else {
-					h.handleNotificationAck()
+					h.handleNotificationAck(response.msg.Platform)
 				}
 				h.waitGroupDone()
 			}
@@ -199,35 +205,35 @@ func (h *messageHandler) HandleResponses() {
 	}
 }
 
-func (h *messageHandler) sendToFeedbackReporters(res interface{}) error {
+func (h *messageHandler) sendToFeedbackReporters(res interface{}, platform string) error {
 	jsonRes, err := json.Marshal(res)
 	if err != nil {
 		return err
 	}
 
 	for _, feedbackReporter := range h.feedbackReporters {
-		feedbackReporter.SendFeedback(h.app, "gcm", jsonRes)
+		feedbackReporter.SendFeedback(h.app, platform, jsonRes)
 	}
 
 	return nil
 }
 
-func (h *messageHandler) handleNotificationSent(topic string) {
+func (h *messageHandler) handleNotificationSent(topic, platform string) {
 	for _, statsReporter := range h.statsReporters {
-		statsReporter.HandleNotificationSent(h.app, "gcm", topic)
+		statsReporter.HandleNotificationSent(h.app, platform, topic)
 	}
 }
 
-func (h *messageHandler) handleNotificationAck() {
+func (h *messageHandler) handleNotificationAck(platform string) {
 	for _, statsReporter := range h.statsReporters {
-		statsReporter.HandleNotificationSuccess(h.app, "gcm")
+		statsReporter.HandleNotificationSuccess(h.app, platform)
 	}
 }
 
-func (h *messageHandler) handleNotificationFailure(message interfaces.Message, err error) {
+func (h *messageHandler) handleNotificationFailure(message interfaces.Message, platform string, err error) {
 	pushError := translateToPushError(err)
 	for _, statsReporter := range h.statsReporters {
-		statsReporter.HandleNotificationFailure(h.app, "gcm", pushError)
+		statsReporter.HandleNotificationFailure(h.app, platform, pushError)
 	}
 	for _, feedbackReporter := range h.feedbackReporters {
 		feedback := &FeedbackResponse{
@@ -236,13 +242,13 @@ func (h *messageHandler) handleNotificationFailure(message interfaces.Message, e
 			From:             message.To,
 		}
 		b, _ := json.Marshal(feedback)
-		feedbackReporter.SendFeedback(h.app, "gcm", b)
+		feedbackReporter.SendFeedback(h.app, platform, b)
 	}
 }
 
-func (h *messageHandler) reportLatency(latency time.Duration) {
+func (h *messageHandler) reportLatency(latency time.Duration, platform string) {
 	for _, statsReporter := range h.statsReporters {
-		statsReporter.ReportSendNotificationLatency(latency, h.app, "gcm", "client", "fcm")
+		statsReporter.ReportSendNotificationLatency(latency, h.app, platform, "client", "fcm")
 	}
 }
 
@@ -252,9 +258,9 @@ func (h *messageHandler) reportFirebaseLatency(latency time.Duration) {
 	}
 }
 
-func (h *messageHandler) reportRateLimitReached(game string) {
+func (h *messageHandler) reportRateLimitReached(game, platform string) {
 	for _, statsReporter := range h.statsReporters {
-		statsReporter.NotificationRateLimitReached(game, "gcm")
+		statsReporter.NotificationRateLimitReached(game, platform)
 	}
 }
 

--- a/extensions/firebase/message_handler_test.go
+++ b/extensions/firebase/message_handler_test.go
@@ -280,6 +280,321 @@ func (s *MessageHandlerTestSuite) TestHandleMessage() {
 		s.waitGroup.Wait()
 	})
 
+	s.Run("should propagate ios platform through dedup, rate limiter, and stats reporters", func() {
+		token := uuid.NewString()
+		msgValue := kafkaFCMMessage{
+			Message: interfaces.Message{
+				To: token,
+				Data: map[string]interface{}{
+					"title": "notification",
+					"body":  "bodyIOS",
+				},
+			},
+			Metadata: map[string]interface{}{
+				"some": "metadata",
+			},
+		}
+		bytes, err := json.Marshal(msgValue)
+		s.Require().NoError(err)
+		msg := interfaces.KafkaMessage{
+			Value:    bytes,
+			Topic:    "push-game_ios-single",
+			Game:     s.game,
+			Platform: "ios",
+		}
+
+		dedupMsg, err := createDedupContentForTest(msgValue)
+		s.Require().NoError(err)
+
+		s.mockDedup.EXPECT().
+			IsUnique(gomock.Any(), token, dedupMsg, s.game, "ios").
+			Return(true)
+
+		s.mockRateLimiter.EXPECT().
+			Allow(gomock.Any(), token, s.game, "ios").
+			Return(true)
+
+		done := make(chan struct{})
+
+		s.mockClient.EXPECT().
+			SendPush(gomock.Any(), gomock.Any()).
+			Do(func(_ context.Context, m interfaces.Message) {
+				s.Equal(token, m.To)
+				s.Equal("ios", m.Platform)
+			})
+
+		s.mockStatsReporter.EXPECT().
+			ReportSendNotificationLatency(gomock.Any(), s.game, "ios", gomock.Any()).Return()
+
+		s.mockStatsReporter.EXPECT().
+			ReportFirebaseLatency(gomock.Any(), s.game, gomock.Any()).Return()
+
+		s.mockStatsReporter.EXPECT().
+			HandleNotificationSent(s.game, "ios", "push-game_ios-single").
+			Do(func(game, platform, topic string) {
+				done <- struct{}{}
+			})
+
+		s.mockStatsReporter.EXPECT().
+			HandleNotificationSuccess(s.game, "ios").
+			Return()
+
+		go s.handler.HandleResponses()
+		s.waitGroup.Add(1)
+		s.handler.HandleMessages(context.Background(), msg)
+
+		timeout := time.NewTimer(5 * time.Second)
+		select {
+		case <-done:
+		case <-timeout.C:
+			s.Fail("timed out waiting for ios message to be processed")
+		}
+		s.waitGroup.Wait()
+	})
+
+	s.Run("should report ios platform on duplicate detected", func() {
+		token := uuid.NewString()
+		msgValue := kafkaFCMMessage{
+			Message: interfaces.Message{
+				To: token,
+				Data: map[string]interface{}{
+					"title": "notification",
+					"body":  "bodyIOSDedup",
+				},
+			},
+		}
+		bytes, err := json.Marshal(msgValue)
+		s.Require().NoError(err)
+		msg := interfaces.KafkaMessage{
+			Value:    bytes,
+			Topic:    "push-game_ios-single",
+			Game:     s.game,
+			Platform: "ios",
+		}
+
+		dedupMsg, err := createDedupContentForTest(msgValue)
+		s.Require().NoError(err)
+
+		s.mockDedup.EXPECT().
+			IsUnique(gomock.Any(), token, dedupMsg, s.game, "ios").
+			Return(false)
+
+		s.mockStatsReporter.EXPECT().
+			ReportMetricCount("duplicated_messages", int64(1), s.game, "ios").
+			Return()
+
+		s.mockRateLimiter.EXPECT().
+			Allow(gomock.Any(), token, s.game, "ios").
+			Return(true)
+
+		done := make(chan struct{})
+
+		s.mockClient.EXPECT().
+			SendPush(gomock.Any(), gomock.Any()).
+			Do(func(_ context.Context, m interfaces.Message) {
+				s.Equal(token, m.To)
+				done <- struct{}{}
+			})
+
+		s.mockStatsReporter.EXPECT().
+			ReportSendNotificationLatency(gomock.Any(), s.game, "ios", gomock.Any()).Return()
+
+		s.mockStatsReporter.EXPECT().
+			ReportFirebaseLatency(gomock.Any(), s.game, gomock.Any()).Return()
+
+		s.mockStatsReporter.EXPECT().
+			HandleNotificationSent(s.game, "ios", "push-game_ios-single").
+			Return()
+
+		s.handler.HandleMessages(context.Background(), msg)
+		timeout := time.NewTimer(50 * time.Millisecond)
+		select {
+		case <-done:
+		case <-timeout.C:
+			s.Fail("timed out waiting for ios dup-detected message to be sent")
+		}
+	})
+
+	s.Run("should report ios platform on rate limit reached", func() {
+		token := uuid.NewString()
+		msgValue := kafkaFCMMessage{
+			Message: interfaces.Message{
+				To: token,
+				Data: map[string]interface{}{
+					"title": "notification",
+					"body":  "bodyIOSRateLimit",
+				},
+			},
+		}
+		bytes, err := json.Marshal(msgValue)
+		s.Require().NoError(err)
+		msg := interfaces.KafkaMessage{
+			Value:    bytes,
+			Topic:    "push-game_ios-single",
+			Game:     s.game,
+			Platform: "ios",
+		}
+
+		dedupMsg, err := createDedupContentForTest(msgValue)
+		s.Require().NoError(err)
+
+		s.mockDedup.EXPECT().
+			IsUnique(gomock.Any(), token, dedupMsg, s.game, "ios").
+			Return(true)
+
+		s.mockRateLimiter.EXPECT().
+			Allow(gomock.Any(), token, s.game, "ios").
+			Return(false)
+
+		s.mockStatsReporter.EXPECT().
+			NotificationRateLimitReached(s.game, "ios").
+			Return()
+
+		s.waitGroup.Add(1)
+		s.handler.HandleMessages(context.Background(), msg)
+		waitWG(s.T(), s.waitGroup)
+	})
+
+	s.Run("should send ios feedback on failure", func() {
+		token := uuid.NewString()
+		msgValue := kafkaFCMMessage{
+			Message: interfaces.Message{
+				To: token,
+				Data: map[string]interface{}{
+					"title": "notification",
+					"body":  "bodyIOSFailure",
+				},
+			},
+		}
+		bytes, err := json.Marshal(msgValue)
+		s.Require().NoError(err)
+		msg := interfaces.KafkaMessage{
+			Value:    bytes,
+			Topic:    "push-game_ios-single",
+			Game:     s.game,
+			Platform: "ios",
+		}
+
+		dedupMsg, err := createDedupContentForTest(msgValue)
+		s.Require().NoError(err)
+
+		s.mockDedup.EXPECT().
+			IsUnique(gomock.Any(), token, dedupMsg, s.game, "ios").
+			Return(true)
+
+		s.mockRateLimiter.EXPECT().
+			Allow(gomock.Any(), token, s.game, "ios").
+			Return(true)
+
+		done := make(chan struct{})
+
+		s.mockClient.EXPECT().
+			SendPush(gomock.Any(), gomock.Any()).
+			Return(errors.NewPushError("DEVICE_UNREGISTERED", "device unregistered"))
+
+		s.mockStatsReporter.EXPECT().
+			ReportSendNotificationLatency(gomock.Any(), s.game, "ios", gomock.Any()).Return()
+
+		s.mockStatsReporter.EXPECT().
+			ReportFirebaseLatency(gomock.Any(), s.game, gomock.Any()).Return()
+
+		s.mockStatsReporter.EXPECT().
+			HandleNotificationSent(s.game, "ios", "push-game_ios-single").
+			Return()
+
+		s.mockStatsReporter.EXPECT().
+			HandleNotificationFailure(s.game, "ios", gomock.Any())
+
+		s.mockFeedbackReporter.EXPECT().
+			SendFeedback(s.game, "ios", gomock.Any()).
+			DoAndReturn(func(game, platform string, feedback []byte) {
+				obj := &FeedbackResponse{}
+				err := json.Unmarshal(feedback, obj)
+				s.NoError(err)
+				s.Equal(token, obj.From)
+				done <- struct{}{}
+			})
+
+		go s.handler.HandleResponses()
+		s.waitGroup.Add(1)
+		s.handler.HandleMessages(context.Background(), msg)
+
+		timeout := time.NewTimer(50 * time.Millisecond)
+		select {
+		case <-done:
+		case <-timeout.C:
+			s.Fail("timed out waiting for ios failure feedback")
+		}
+	})
+
+	s.Run("should default empty platform to gcm for backward compatibility", func() {
+		token := uuid.NewString()
+		msgValue := kafkaFCMMessage{
+			Message: interfaces.Message{
+				To: token,
+				Data: map[string]interface{}{
+					"title": "notification",
+					"body":  "bodyEmptyPlatform",
+				},
+			},
+		}
+		bytes, err := json.Marshal(msgValue)
+		s.Require().NoError(err)
+		// Platform is intentionally left empty.
+		msg := interfaces.KafkaMessage{
+			Value: bytes,
+			Topic: "push-game_gcm-single",
+			Game:  s.game,
+		}
+
+		dedupMsg, err := createDedupContentForTest(msgValue)
+		s.Require().NoError(err)
+
+		s.mockDedup.EXPECT().
+			IsUnique(gomock.Any(), token, dedupMsg, s.game, "gcm").
+			Return(true)
+
+		s.mockRateLimiter.EXPECT().
+			Allow(gomock.Any(), token, s.game, "gcm").
+			Return(true)
+
+		done := make(chan struct{})
+
+		s.mockClient.EXPECT().
+			SendPush(gomock.Any(), gomock.Any()).
+			Do(func(_ context.Context, m interfaces.Message) {
+				s.Equal("gcm", m.Platform)
+			})
+
+		s.mockStatsReporter.EXPECT().
+			ReportSendNotificationLatency(gomock.Any(), s.game, "gcm", gomock.Any()).Return()
+
+		s.mockStatsReporter.EXPECT().
+			ReportFirebaseLatency(gomock.Any(), s.game, gomock.Any()).Return()
+
+		s.mockStatsReporter.EXPECT().
+			HandleNotificationSent(s.game, "gcm", "push-game_gcm-single").
+			Do(func(game, platform, topic string) {
+				done <- struct{}{}
+			})
+
+		s.mockStatsReporter.EXPECT().
+			HandleNotificationSuccess(s.game, "gcm").
+			Return()
+
+		go s.handler.HandleResponses()
+		s.waitGroup.Add(1)
+		s.handler.HandleMessages(context.Background(), msg)
+
+		timeout := time.NewTimer(5 * time.Second)
+		select {
+		case <-done:
+		case <-timeout.C:
+			s.Fail("timed out waiting for empty-platform message to be processed")
+		}
+		s.waitGroup.Wait()
+	})
+
 	s.Run("should not lock sendPushConcurrencyControl when sending multiple messages", func() {
 		newMessage := func() kafkaFCMMessage {
 			token := uuid.NewString()

--- a/interfaces/client.go
+++ b/interfaces/client.go
@@ -18,6 +18,7 @@ type Message struct {
 	DryRun                   bool          `json:"dry_run,omitempty"`
 	Data                     Data          `json:"data,omitempty"`
 	Notification             *Notification `json:"notification,omitempty"`
+	Platform                 string        `json:"-"`
 }
 
 // Data defines the custom payload of a message.


### PR DESCRIPTION
Adds a Platform field to interfaces.Message and resolves the platform ("gcm" or "ios", with empty string falling back to "gcm") from KafkaMessage.Platform at the top of HandleMessages. The resolved value is threaded through dedup, rate limiting, the duplicate-detected stat, sendPush, HandleResponses, and every feedback/stats reporter call — replacing the hardcoded "gcm" literals so iOS messages are tagged correctly across observability paths.

The Firebase client still produces Android-style payloads, so this is non-breaking until upstream services start publishing on _ios-* topics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `interfaces.Message` and changes Firebase message handling/metrics tagging; mistakes could mis-label stats/feedback or break downstream implementations that construct `Message` structs.
> 
> **Overview**
> Resolves `platform` from `KafkaMessage.Platform` (defaulting to `gcm`) and stores it on `interfaces.Message`, then threads it through Firebase push handling so dedup, rate limiting, latency metrics, sent/ack/failure stats, and feedback reporting are tagged with the correct platform instead of a hardcoded `gcm`.
> 
> Adds extensive tests covering iOS propagation, duplicate-detected/rate-limit/failure feedback paths, and the empty-platform fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526880f087aa6a2b208baf3a80207034fa3ef538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->