### PR TITLE
feat(firebase): build APNS payload for iOS messages

### DIFF
--- a/extensions/firebase/client/firebase.go
+++ b/extensions/firebase/client/firebase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"time"
 
 	firebase "firebase.google.com/go/v4"
@@ -94,6 +95,13 @@ func getProjectIDFromJson(jsonStr string) (string, error) {
 }
 
 func toFirebaseMessage(message interfaces.Message) messaging.Message {
+	if message.Platform == "ios" {
+		return buildIOSMessage(message)
+	}
+	return buildAndroidMessage(message)
+}
+
+func buildAndroidMessage(message interfaces.Message) messaging.Message {
 	firebaseMessage := messaging.Message{
 		Token: message.To,
 	}
@@ -137,6 +145,68 @@ func toFirebaseMessage(message interfaces.Message) messaging.Message {
 			firebaseMessage.Android.TTL = &ttl
 		}
 	}
+
+	return firebaseMessage
+}
+
+func buildIOSMessage(message interfaces.Message) messaging.Message {
+	firebaseMessage := messaging.Message{
+		Token: message.To,
+	}
+
+	if message.Data != nil {
+		firebaseMessage.Data = toMapString(message.Data)
+	}
+
+	apns := &messaging.APNSConfig{
+		Headers: map[string]string{},
+	}
+	if message.CollapseKey != "" {
+		apns.Headers["apns-collapse-id"] = message.CollapseKey
+	}
+	if message.Priority != "" {
+		apns.Headers["apns-priority"] = message.Priority
+	}
+	if message.TimeToLive != nil {
+		expiration := time.Now().Add(time.Duration(*message.TimeToLive) * time.Second).Unix()
+		apns.Headers["apns-expiration"] = strconv.FormatInt(expiration, 10)
+	}
+
+	aps := &messaging.Aps{
+		ContentAvailable: message.ContentAvailable,
+	}
+
+	if message.Notification != nil {
+		firebaseMessage.Notification = &messaging.Notification{
+			Title:    message.Notification.Title,
+			Body:     message.Notification.Body,
+			ImageURL: message.Notification.ImageUrl,
+		}
+
+		alert := &messaging.ApsAlert{
+			Title:       message.Notification.Title,
+			Body:        message.Notification.Body,
+			LocKey:      message.Notification.BodyLocKey,
+			TitleLocKey: message.Notification.TitleLocKey,
+		}
+		if message.Notification.BodyLocArgs != "" {
+			alert.LocArgs = []string{message.Notification.BodyLocArgs}
+		}
+		if message.Notification.TitleLocArgs != "" {
+			alert.TitleLocArgs = []string{message.Notification.TitleLocArgs}
+		}
+		aps.Alert = alert
+		aps.Sound = message.Notification.Sound
+
+		if message.Notification.Badge != "" {
+			if badge, err := strconv.Atoi(message.Notification.Badge); err == nil {
+				aps.Badge = &badge
+			}
+		}
+	}
+
+	apns.Payload = &messaging.APNSPayload{Aps: aps}
+	firebaseMessage.APNS = apns
 
 	return firebaseMessage
 }

--- a/extensions/firebase/client/firebase_apns_test.go
+++ b/extensions/firebase/client/firebase_apns_test.go
@@ -1,0 +1,210 @@
+package client
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/topfreegames/pusher/interfaces"
+)
+
+func TestToFirebaseMessage_IOSBuildsAPNSOnly(t *testing.T) {
+	msg := interfaces.Message{
+		To:       "ios-token",
+		Platform: "ios",
+		Notification: &interfaces.Notification{
+			Title: "hello",
+			Body:  "world",
+			Sound: "default",
+		},
+	}
+
+	out := toFirebaseMessage(msg)
+
+	require.NotNil(t, out.APNS)
+	require.NotNil(t, out.APNS.Payload)
+	require.NotNil(t, out.APNS.Payload.Aps)
+	require.NotNil(t, out.APNS.Payload.Aps.Alert)
+	assert.Equal(t, "hello", out.APNS.Payload.Aps.Alert.Title)
+	assert.Equal(t, "world", out.APNS.Payload.Aps.Alert.Body)
+	assert.Equal(t, "default", out.APNS.Payload.Aps.Sound)
+	assert.Nil(t, out.Android, "iOS message must not populate Android config")
+}
+
+func TestToFirebaseMessage_GCMBuildsAndroidOnly(t *testing.T) {
+	msg := interfaces.Message{
+		To:       "android-token",
+		Platform: "gcm",
+		Notification: &interfaces.Notification{
+			Title: "hello",
+			Body:  "world",
+		},
+	}
+
+	out := toFirebaseMessage(msg)
+
+	require.NotNil(t, out.Android)
+	require.NotNil(t, out.Android.Notification)
+	assert.Equal(t, "hello", out.Android.Notification.Title)
+	assert.Nil(t, out.APNS, "Android message must not populate APNS config")
+}
+
+func TestToFirebaseMessage_EmptyPlatformDefaultsToAndroid(t *testing.T) {
+	msg := interfaces.Message{
+		To:       "android-token",
+		Platform: "",
+		Notification: &interfaces.Notification{
+			Title: "hello",
+			Body:  "world",
+		},
+	}
+
+	out := toFirebaseMessage(msg)
+
+	require.NotNil(t, out.Android)
+	assert.Nil(t, out.APNS)
+}
+
+func TestBuildIOSMessage_BadgeStringToInt(t *testing.T) {
+	msg := interfaces.Message{
+		To:       "ios-token",
+		Platform: "ios",
+		Notification: &interfaces.Notification{
+			Title: "t",
+			Body:  "b",
+			Badge: "42",
+		},
+	}
+
+	out := toFirebaseMessage(msg)
+
+	require.NotNil(t, out.APNS.Payload.Aps.Badge)
+	assert.Equal(t, 42, *out.APNS.Payload.Aps.Badge)
+}
+
+func TestBuildIOSMessage_BadgeInvalidStringIsOmitted(t *testing.T) {
+	msg := interfaces.Message{
+		To:       "ios-token",
+		Platform: "ios",
+		Notification: &interfaces.Notification{
+			Title: "t",
+			Body:  "b",
+			Badge: "not-a-number",
+		},
+	}
+
+	out := toFirebaseMessage(msg)
+
+	assert.Nil(t, out.APNS.Payload.Aps.Badge)
+}
+
+func TestBuildIOSMessage_BadgeEmptyIsOmitted(t *testing.T) {
+	msg := interfaces.Message{
+		To:       "ios-token",
+		Platform: "ios",
+		Notification: &interfaces.Notification{
+			Title: "t",
+			Body:  "b",
+		},
+	}
+
+	out := toFirebaseMessage(msg)
+
+	assert.Nil(t, out.APNS.Payload.Aps.Badge)
+}
+
+func TestBuildIOSMessage_SilentPush(t *testing.T) {
+	msg := interfaces.Message{
+		To:               "ios-token",
+		Platform:         "ios",
+		ContentAvailable: true,
+		Data:             interfaces.Data{"k": "v"},
+	}
+
+	out := toFirebaseMessage(msg)
+
+	require.NotNil(t, out.APNS)
+	require.NotNil(t, out.APNS.Payload)
+	require.NotNil(t, out.APNS.Payload.Aps)
+	assert.True(t, out.APNS.Payload.Aps.ContentAvailable)
+	assert.Nil(t, out.APNS.Payload.Aps.Alert, "silent push must not include an alert")
+	assert.Nil(t, out.Notification, "silent push must not include a top-level Notification")
+	assert.Equal(t, map[string]string{"k": "v"}, out.Data)
+}
+
+func TestBuildIOSMessage_CollapseKeyAndTTLProduceHeaders(t *testing.T) {
+	ttl := uint(60)
+	msg := interfaces.Message{
+		To:          "ios-token",
+		Platform:    "ios",
+		CollapseKey: "collapse-1",
+		Priority:    "10",
+		TimeToLive:  &ttl,
+		Notification: &interfaces.Notification{
+			Title: "t",
+			Body:  "b",
+		},
+	}
+
+	before := time.Now().Unix()
+	out := toFirebaseMessage(msg)
+	after := time.Now().Unix()
+
+	require.NotNil(t, out.APNS)
+	headers := out.APNS.Headers
+	assert.Equal(t, "collapse-1", headers["apns-collapse-id"])
+	assert.Equal(t, "10", headers["apns-priority"])
+
+	expStr, ok := headers["apns-expiration"]
+	require.True(t, ok, "apns-expiration header must be set when TTL provided")
+	exp, err := strconv.ParseInt(expStr, 10, 64)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, exp, before+int64(ttl))
+	assert.LessOrEqual(t, exp, after+int64(ttl))
+}
+
+func TestBuildIOSMessage_OmitsHeadersWhenNotProvided(t *testing.T) {
+	msg := interfaces.Message{
+		To:       "ios-token",
+		Platform: "ios",
+		Notification: &interfaces.Notification{
+			Title: "t",
+			Body:  "b",
+		},
+	}
+
+	out := toFirebaseMessage(msg)
+
+	require.NotNil(t, out.APNS)
+	_, hasCollapse := out.APNS.Headers["apns-collapse-id"]
+	_, hasPriority := out.APNS.Headers["apns-priority"]
+	_, hasExpiration := out.APNS.Headers["apns-expiration"]
+	assert.False(t, hasCollapse)
+	assert.False(t, hasPriority)
+	assert.False(t, hasExpiration)
+}
+
+func TestBuildIOSMessage_LocKeysAndArgs(t *testing.T) {
+	msg := interfaces.Message{
+		To:       "ios-token",
+		Platform: "ios",
+		Notification: &interfaces.Notification{
+			BodyLocKey:   "body.key",
+			BodyLocArgs:  "arg1",
+			TitleLocKey:  "title.key",
+			TitleLocArgs: "title-arg",
+		},
+	}
+
+	out := toFirebaseMessage(msg)
+
+	require.NotNil(t, out.APNS.Payload.Aps.Alert)
+	alert := out.APNS.Payload.Aps.Alert
+	assert.Equal(t, "body.key", alert.LocKey)
+	assert.Equal(t, []string{"arg1"}, alert.LocArgs)
+	assert.Equal(t, "title.key", alert.TitleLocKey)
+	assert.Equal(t, []string{"title-arg"}, alert.TitleLocArgs)
+}
+


### PR DESCRIPTION
toFirebaseMessage branches on Message.Platform: "ios" routes to buildIOSMessage, anything else (including the empty default) keeps the existing Android logic via buildAndroidMessage.

buildIOSMessage produces a messaging.APNSConfig with apns-collapse-id, apns-priority and apns-expiration headers (when the corresponding Message fields are set), and an Aps payload covering alert title/body/loc-keys/loc-args, sound, badge (parsed from string to int, silently dropped if not numeric) and content-available for silent pushes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Firebase push payloads are constructed based on `Message.Platform`, which can affect iOS/Android notification delivery and header/TTL semantics. Adds new APNS-specific logic that must match Apple/FCM expectations to avoid silently dropped pushes.
> 
> **Overview**
> Routes `toFirebaseMessage` based on `Message.Platform`, keeping existing behavior in a new `buildAndroidMessage` and adding `buildIOSMessage` for `"ios"`.
> 
> For iOS, builds an APNS config with optional `apns-collapse-id`, `apns-priority`, and `apns-expiration` headers (derived from `TimeToLive`), plus an `aps` payload supporting *silent pushes* (`content-available`) and notification fields (alert title/body/localization keys/args, sound, and badge parsed from string).
> 
> Adds `firebase_apns_test.go` to cover iOS vs Android branching, silent push behavior, header generation, localization fields, and badge parsing/omission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbd31eedf194c1ec68a2052f3ffb79b47e893485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->